### PR TITLE
Fix mixed-mode search consistency

### DIFF
--- a/electron/db.js
+++ b/electron/db.js
@@ -1250,6 +1250,26 @@ class TimelineDB {
     // Concatenate all columns into one string — 1 LIKE per term instead of N per column.
     if (!meta.ftsReady) {
       const concat = meta.safeCols.map((c) => `COALESCE(${c.safe},'')`).join(" || ' ' || ");
+      if (searchMode === "mixed") {
+        const mixed = this._parseMixedSearch(searchTerm, meta);
+        const mixedConditions = [];
+        for (const term of mixed.positiveTerms) {
+          params.push(`%${term}%`);
+          mixedConditions.push(`(${concat}) LIKE ?`);
+        }
+        for (const term of mixed.negativeTerms) {
+          params.push(`%${term}%`);
+          mixedConditions.push(`(${concat}) NOT LIKE ?`);
+        }
+        if (mixedConditions.length > 0) {
+          whereConditions.push(`(${mixedConditions.join(" AND ")})`);
+        }
+        for (const cc of mixed.colConditions) {
+          whereConditions.push(cc.sql);
+          params.push(cc.param);
+        }
+        return;
+      }
       const terms = searchMode === "exact" ? [searchTerm.trim()] : searchTerm.trim().split(/\s+/).filter(Boolean);
       const joinOp = (searchMode === "or") ? " OR " : " AND ";
       const termConditions = terms.map((term) => {
@@ -1259,10 +1279,26 @@ class TimelineDB {
       whereConditions.push(`(${termConditions.join(joinOp)})`);
       return;
     }
-    const { ftsQuery, colConditions } = this._buildSearchQuery(searchTerm, searchMode, meta);
-    if (ftsQuery) {
-      whereConditions.push(`data.rowid IN (SELECT rowid FROM data_fts WHERE data_fts MATCH ?)`);
-      params.push(ftsQuery);
+    const { ftsQuery, colConditions, likeSupplement, negativeTerms = [] } = this._buildSearchQuery(searchTerm, searchMode, meta);
+    if (ftsQuery || likeSupplement) {
+      const concat = meta.safeCols.map((c) => `COALESCE(${c.safe},'')`).join(" || ' ' || ");
+      if (ftsQuery && likeSupplement) {
+        whereConditions.push(`(data.rowid IN (SELECT rowid FROM data_fts WHERE data_fts MATCH ?) OR (${concat}) LIKE ?)`);
+        params.push(ftsQuery, likeSupplement);
+      } else if (ftsQuery) {
+        whereConditions.push(`data.rowid IN (SELECT rowid FROM data_fts WHERE data_fts MATCH ?)`);
+        params.push(ftsQuery);
+      } else {
+        whereConditions.push(`(${concat}) LIKE ?`);
+        params.push(likeSupplement);
+      }
+    }
+    if (!ftsQuery && negativeTerms.length > 0) {
+      const concat = meta.safeCols.map((c) => `COALESCE(${c.safe},'')`).join(" || ' ' || ");
+      for (const term of negativeTerms) {
+        params.push(`%${term}%`);
+        whereConditions.push(`(${concat}) NOT LIKE ?`);
+      }
     }
     for (const cc of colConditions) {
       whereConditions.push(cc.sql);
@@ -1445,15 +1481,90 @@ class TimelineDB {
   }
 
   /**
+   * Parse mixed-mode search syntax into free-text and column-specific components.
+   */
+  _parseMixedSearch(searchTerm, meta) {
+    const tokens = [];
+    const regex = /"([^"]+)"|(\S+)/g;
+    let m;
+    while ((m = regex.exec(searchTerm)) !== null) {
+      tokens.push(m[1] ? `"${m[1]}"` : m[2]);
+    }
+
+    const parsed = {
+      tokens,
+      ftsTerms: [],
+      positiveTerms: [],
+      negativeTerms: [],
+      colConditions: [],
+      hasOperator: false,
+      hasQuotedPhrase: false,
+      hasColumnFilter: false,
+    };
+
+    for (const token of tokens) {
+      if (token.startsWith('"')) {
+        parsed.hasQuotedPhrase = true;
+        const phrase = token.slice(1, -1).replace(/"/g, "").trim();
+        if (!phrase) continue;
+        parsed.ftsTerms.push(`"${phrase}"`);
+        parsed.positiveTerms.push(phrase);
+        continue;
+      }
+
+      if (token.includes(":")) {
+        const colonIdx = token.indexOf(":");
+        const colPart = token.substring(0, colonIdx);
+        const valPart = token.substring(colonIdx + 1);
+        if (valPart) {
+          const matchCol = meta.headers.find((h) => h.toLowerCase() === colPart.toLowerCase());
+          const safeCol = matchCol ? meta.colMap[matchCol] : null;
+          if (safeCol) {
+            parsed.hasColumnFilter = true;
+            parsed.colConditions.push({ sql: `${safeCol} LIKE ?`, param: `%${valPart}%` });
+            continue;
+          }
+        }
+      }
+
+      if (token.startsWith("-")) {
+        parsed.hasOperator = true;
+        const term = token.slice(1).replace(/"/g, "").trim();
+        if (!term) continue;
+        parsed.ftsTerms.push(`NOT "${term}"`);
+        parsed.negativeTerms.push(term);
+        continue;
+      }
+
+      if (token.startsWith("+")) {
+        parsed.hasOperator = true;
+        const term = token.slice(1).replace(/"/g, "").trim();
+        if (!term) continue;
+        parsed.ftsTerms.push(`"${term}"`);
+        parsed.positiveTerms.push(term);
+        continue;
+      }
+
+      const cleaned = token.replace(/"/g, "").trim();
+      if (!cleaned) continue;
+      parsed.ftsTerms.push(`"${cleaned}"`);
+      parsed.positiveTerms.push(cleaned);
+    }
+
+    return parsed;
+  }
+
+  /**
    * Build search query from search term and mode.
    * Returns { ftsQuery, colConditions } where:
    *   - ftsQuery: FTS5 MATCH string (or null if no FTS terms)
    *   - colConditions: array of { sql, param } for column-specific Col:value filters
+   *   - likeSupplement: optional LIKE pattern used to broaden mixed-mode contains searches
    */
   _buildSearchQuery(searchTerm, searchMode, meta) {
     // Lazy-build FTS index on first search
     this._ensureFts(meta.tabId);
-    const result = { ftsQuery: null, colConditions: [] };
+    const result = { ftsQuery: null, colConditions: [], likeSupplement: null, negativeTerms: [] };
     try {
       if (searchMode === "exact") {
         const cleaned = searchTerm.replace(/"/g, "").trim();
@@ -1474,45 +1585,27 @@ class TimelineDB {
       }
 
       // Mixed mode — parse +AND, -EXCLUDE, "phrases", Column:value
-      const tokens = [];
-      const regex = /"([^"]+)"|(\S+)/g;
-      let m;
-      while ((m = regex.exec(searchTerm)) !== null) {
-        tokens.push(m[1] ? `"${m[1]}"` : m[2]);
-      }
+      const mixed = this._parseMixedSearch(searchTerm, meta);
+      const { ftsTerms, hasOperator, hasQuotedPhrase, hasColumnFilter } = mixed;
+      result.colConditions = mixed.colConditions;
+      result.negativeTerms = mixed.negativeTerms;
 
-      const ftsTerms = [];
-      for (const token of tokens) {
-        if (token.startsWith('"')) {
-          ftsTerms.push(token);
-        } else if (token.includes(":")) {
-          // Column-specific filter: Col:value → WHERE colSafe LIKE %value%
-          const colonIdx = token.indexOf(":");
-          const colPart = token.substring(0, colonIdx);
-          const valPart = token.substring(colonIdx + 1);
-          if (valPart) {
-            // Find matching column (case-insensitive)
-            const matchCol = meta.headers.find((h) => h.toLowerCase() === colPart.toLowerCase());
-            const safeCol = matchCol ? meta.colMap[matchCol] : null;
-            if (safeCol) {
-              result.colConditions.push({ sql: `${safeCol} LIKE ?`, param: `%${valPart}%` });
-            }
-          }
-        } else if (token.startsWith("-")) {
-          const term = token.slice(1);
-          if (term) ftsTerms.push(`NOT "${term}"`);
-        } else if (token.startsWith("+")) {
-          const term = token.slice(1);
-          if (term) ftsTerms.push(`"${term}"`);
-        } else {
-          ftsTerms.push(`"${token}"`);
+      const positiveFtsTerms = ftsTerms.filter((term) => !term.startsWith("NOT "));
+
+      if (positiveFtsTerms.length > 0) {
+        // Default to AND for multi-word (DFIR analysts want all terms to match)
+        result.ftsQuery = positiveFtsTerms.join(hasOperator ? " AND " : (positiveFtsTerms.length > 1 ? " AND " : ""));
+        for (const term of mixed.negativeTerms) {
+          result.ftsQuery += ` NOT "${term.replace(/"/g, "")}"`;
         }
       }
 
-      if (ftsTerms.length > 0) {
-        const hasOperator = tokens.some((t) => t.startsWith("+") || t.startsWith("-"));
-        // Default to AND for multi-word (DFIR analysts want all terms to match)
-        result.ftsQuery = ftsTerms.join(hasOperator ? " AND " : (ftsTerms.length > 1 ? " AND " : ""));
+      // Mixed mode supplements FTS with substring matching for phrase-like or
+      // punctuation-heavy searches (paths, hashes, obfuscated strings, etc.).
+      const trimmed = searchTerm.trim();
+      const plainQuery = !hasOperator && !hasQuotedPhrase && !hasColumnFilter;
+      if (plainQuery && trimmed && (/\s/.test(trimmed) || /[^A-Za-z]/.test(trimmed))) {
+        result.likeSupplement = `%${trimmed}%`;
       }
 
       return result;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1662,7 +1662,7 @@ export default function App() {
       setCrossTabCounts({ term, mode, cond, results });
     }, 600);
     return () => { if (crossTabTimer.current) clearTimeout(crossTabTimer.current); };
-  }, [ct?.searchTerm, ct?.searchMode, tabs.length, tle]); // eslint-disable-line
+  }, [ct?.searchTerm, ct?.searchMode, ct?.searchCondition, tabs.length, tle]); // eslint-disable-line
 
   // ── Reset column widths ────────────────────────────────────────
   const resetColumnWidths = useCallback(() => {
@@ -2873,7 +2873,7 @@ export default function App() {
         </div>
       ))}
       <h4 style={{ color: th.text, fontSize: 12, marginTop: 12, marginBottom: 6 }}>Mixed Search Syntax</h4>
-      {[["word1 word2", "OR"], ["+word", "AND (must include)"], ["-word", "EXCLUDE"], ['"exact phrase"', "Phrase"], ["Column:value", "Column filter"]].map(([s, d]) => (
+      {[["word1 word2", "AND"], ["+word", "AND (must include)"], ["-word", "EXCLUDE"], ['"exact phrase"', "Phrase"], ["Column:value", "Column filter"]].map(([s, d]) => (
         <div key={s} style={{ fontSize: 12, color: th.textDim, padding: "2px 0" }}>
           <code style={{ background: th.btnBg, padding: "1px 5px", borderRadius: 3, color: th.accent }}>{s}</code> — {d}
         </div>
@@ -3679,7 +3679,7 @@ export default function App() {
         <div style={{ display: "flex", alignItems: "center", gap: 4, padding: "3px 12px", background: th.panelBg, borderBottom: `1px solid ${th.border}`, flexShrink: 0, overflowX: "auto" }}>
           <span style={{ color: th.textMuted, fontSize: 10, whiteSpace: "nowrap", marginRight: 4 }}>Across tabs:</span>
           {crossTabCounts.results.map((r) => (
-            <button key={r.tabId} onClick={() => { if (r.count > 0) { setActiveTab(r.tabId); setTabs((prev) => prev.map((t) => t.id === r.tabId ? { ...t, searchTerm: crossTabCounts.term, searchMode: crossTabCounts.mode } : t)); } }}
+            <button key={r.tabId} onClick={() => { if (r.count > 0) { setActiveTab(r.tabId); setTabs((prev) => prev.map((t) => t.id === r.tabId ? { ...t, searchTerm: crossTabCounts.term, searchMode: crossTabCounts.mode, searchCondition: crossTabCounts.cond || "contains" } : t)); } }}
               style={{ display: "flex", alignItems: "center", gap: 3, padding: "1px 8px", borderRadius: 10, border: `1px solid ${r.count > 0 ? th.borderAccent + "66" : th.border}`, background: r.tabId === activeTab ? th.selection : "transparent", cursor: r.count > 0 ? "pointer" : "default", fontSize: 10, color: r.count > 0 ? th.text : th.textMuted, whiteSpace: "nowrap" }}>
               <span style={{ maxWidth: 120, overflow: "hidden", textOverflow: "ellipsis" }}>{r.name}</span>
               <span style={{ color: r.count > 0 ? th.success : th.textMuted, fontWeight: 600 }}>{formatNumber(r.count)}</span>


### PR DESCRIPTION
Fixes https://github.com/r3nzsec/irflow-timeline/issues/8

## Summary

This PR fixes inconsistencies between global search and column filters.

## What changed

- made mixed-mode global search supplement FTS with substring matching for phrase-like and punctuation-heavy queries
- prevented non-column `foo:bar` tokens from being misinterpreted as column filters
- added proper mixed-mode fallback behavior while FTS is still building
- made `Column:value`, `+must`, and `-exclude` behave consistently before and after FTS readiness
- fixed cross-tab search counts and tab switching to respect the active search condition

## Why

Saw a case where:
- global search returned fewer results than column filters
- `Contains` behaved differently depending on whether the query was typed globally or as a column filter
- behavior changed while FTS was still building
- cross-tab counts did not fully reflect the current search configuration

## Testing

Validated with targeted searches for:
- `b4ckd00r`
- `Message:b4ckd00r`
- `+alpha -beta`
- `-beta`

Before: 
<img width="2978" height="440" alt="image" src="https://github.com/user-attachments/assets/80a6cf14-3179-416a-b439-22cc31805b26" />

After: 
<img width="2986" height="666" alt="image" src="https://github.com/user-attachments/assets/3b0fb6da-0b41-4621-823d-e19740e0546f" />


Also checked behavior both before and after FTS readiness.
