### PR TITLE
Release v1.0.8: fix clean CI validation

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -99,6 +99,7 @@ jobs:
       # the Node ABI, so SQLite-backed tests run here instead of being skipped
       # after the native module is rebuilt for Electron.
       - name: Run test suite
+        timeout-minutes: 10
         run: npm test
 
       - name: Build renderer

--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,8 @@ tools/jumplist-parser/
 tools/shellbag-parser/
 tools/artemis/
 .claude/
+# Claude fixture directories intentionally model the real artifact path.
+!tests/fixtures/**/.claude/
+!tests/fixtures/**/.claude/**
 *.bak
 *.code-workspace

--- a/electron/db.js
+++ b/electron/db.js
@@ -180,6 +180,8 @@ class TimelineDB {
       headers,
       safeCols,
       tsColumns,
+      numericColumns: new Set(),
+      indexedCols: new Set(),
       rowCount: 0,
       ftsReady: false,
       isLargeFile,

--- a/electron/db/query-store.js
+++ b/electron/db/query-store.js
@@ -1170,7 +1170,11 @@ class QueryStoreMethods {
     let sql;
     if (distinct && isTsCol) {
       // Same instant can appear as ISO T/Z, space-separated, fractional seconds, etc.
-      const tsKey = `sort_datetime(${safeCol})`;
+      const rawTsKey = `sort_datetime(${safeCol})`;
+      // Normalize representation-only trailing fractional zeroes without changing
+      // sort_datetime() itself, whose fixed-width UTC output is part of the query API.
+      const tsKey = `CASE WHEN INSTR(${rawTsKey}, '.') > 0 `
+        + `THEN RTRIM(RTRIM(${rawTsKey}, '0'), '.') ELSE ${rawTsKey} END`;
       sql = `SELECT MIN(${valExpr}) AS val FROM ${fromExpr} ${whereClause} GROUP BY ${tsKey} ORDER BY MIN(${tsKey}) ${sortDirSql} LIMIT ?`;
     } else if (distinct && sortKey) {
       // Text: trim + case-insensitive group; order follows the grid sort column.

--- a/tests/column-copy-values.test.js
+++ b/tests/column-copy-values.test.js
@@ -12,8 +12,9 @@ const TimelineDB = require("../electron/db");
 
 test("getColumnValues follows grid sortCol/sortDir, not import rowid order",
   { skip: HAVE_SQLITE ? false : "better-sqlite3 native module not built for this runtime" },
-  () => {
+  (t) => {
     const db = new TimelineDB();
+    t.after(() => db.closeAll());
     const tabId = "sort-copy-tab";
     const headers = ["TimeCreated", "Channel"];
     db.createTab(tabId, headers);
@@ -47,15 +48,13 @@ test("getColumnValues follows grid sortCol/sortDir, not import rowid order",
       "2026-04-29 10:00:00",
       "2026-04-29 08:00:00",
     ]);
-
-    db.closeTab(tabId);
-    db.closeAll();
   });
 
 test("getColumnValues distinct collapses timestamp format variants to one value",
   { skip: HAVE_SQLITE ? false : "better-sqlite3 native module not built for this runtime" },
-  () => {
+  (t) => {
     const db = new TimelineDB();
+    t.after(() => db.closeAll());
     const tabId = "distinct-ts-tab";
     db.createTab(tabId, ["TimeCreated"]);
     const meta = db.databases.get(tabId);
@@ -74,7 +73,4 @@ test("getColumnValues distinct collapses timestamp format variants to one value"
       sortDir: "asc",
     });
     assert.equal(unique.values.length, 1);
-
-    db.closeTab(tabId);
-    db.closeAll();
   });

--- a/tests/column-unique-values.test.js
+++ b/tests/column-unique-values.test.js
@@ -15,8 +15,9 @@ const TimelineDB = require("../electron/db");
 
 test("getColumnUniqueValues samples unindexed columns on large tabs",
   { skip: HAVE_SQLITE ? false : "better-sqlite3 native module not built for this runtime" },
-  () => {
+  (t) => {
     const db = new TimelineDB();
+    t.after(() => db.closeAll());
     const tabId = "large-sample-tab";
     const headers = ["TimeCreated", "Channel"];
     db.createTab(tabId, headers);
@@ -29,18 +30,17 @@ test("getColumnUniqueValues samples unindexed columns on large tabs",
     for (let i = 0; i < 2000; i++) {
       ins.run(`2024-01-01 00:00:${String(i % 60).padStart(2, "0")}`, i % 3 === 0 ? "Security" : "Sysmon");
     }
-    meta.rowCount = 2000;
+    // Preserve the large-file population metadata while keeping the fixture small.
+    meta.rowCount = 1_000_000;
 
     const full = db.getColumnUniqueValues(tabId, "Channel", { limit: 100 });
     assert.ok(full.sampled, "unindexed column on large tab should be sampled");
-    assert.ok(full.some((r) => r.val === "Security"));
-    assert.ok(full.some((r) => r.val === "Sysmon"));
+    assert.ok(full.values.some((r) => r.val === "Security"));
+    assert.ok(full.values.some((r) => r.val === "Sysmon"));
 
     const indexed = db.getColumnUniqueValues(tabId, "TimeCreated", { limit: 100 });
     assert.equal(indexed.sampled, undefined, "indexed timestamp column uses full GROUP BY");
-
-    db.closeTab(tabId);
-    db.closeAll();
+    assert.ok(Array.isArray(indexed.values));
   });
 
 test("query-store exports sample tuning constants", () => {
@@ -50,8 +50,9 @@ test("query-store exports sample tuning constants", () => {
 
 test("getColumnUniqueValues accepts checkboxFilters as Set (AI history default Role filter)",
   { skip: HAVE_SQLITE ? false : "better-sqlite3 native module not built for this runtime" },
-  () => {
+  (t) => {
     const db = new TimelineDB();
+    t.after(() => db.closeAll());
     const tabId = "checkbox-set-tab";
     const headers = ["Role", "Tool"];
     db.createTab(tabId, headers);
@@ -62,15 +63,13 @@ test("getColumnUniqueValues accepts checkboxFilters as Set (AI history default R
     ins.run("user", "Claude Code");
     meta.rowCount = 3;
 
-    const vals = db.getColumnUniqueValues(tabId, "Tool", {
+    const result = db.getColumnUniqueValues(tabId, "Tool", {
       checkboxFilters: { Role: new Set(["user"]) },
       limit: 100,
     });
+    const vals = result.values;
     assert.ok(Array.isArray(vals));
     assert.equal(vals.length, 2);
     const tools = vals.map((r) => r.val).sort();
     assert.deepEqual(tools, ["Claude Code", "OpenAI Codex"]);
-
-    db.closeTab(tabId);
-    db.closeAll();
   });

--- a/tests/date-range-filter.test.js
+++ b/tests/date-range-filter.test.js
@@ -12,8 +12,9 @@ const TimelineDB = require("../electron/db");
 
 test("date range filter matches timestamp format variants via sort_datetime",
   { skip: HAVE_SQLITE ? false : "better-sqlite3 native module not built for this runtime" },
-  () => {
+  (t) => {
     const db = new TimelineDB();
+    t.after(() => db.closeAll());
     const tabId = "date-range-tab";
     db.createTab(tabId, ["TimeCreated"]);
     const meta = db.databases.get(tabId);
@@ -40,7 +41,4 @@ test("date range filter matches timestamp format variants via sort_datetime",
       inRange.rows.map((r) => r.TimeCreated),
       ["2026-04-29 10:00:00", "2026-04-29T12:00:00Z"],
     );
-
-    db.closeTab(tabId);
-    db.closeAll();
   });

--- a/tests/fixtures/ai-history/claude-desktop/.claude/projects/demo-app/sess-abc.jsonl
+++ b/tests/fixtures/ai-history/claude-desktop/.claude/projects/demo-app/sess-abc.jsonl
@@ -1,0 +1,3 @@
+{"type":"user","timestamp":"2024-01-01T12:00:00.000Z","uuid":"msg-user-1","parentUuid":"","sessionId":"sess-abc","cwd":"/tmp/demo-project","message":{"role":"user","content":[{"type":"text","text":"Explain this function"}]}}
+{"type":"assistant","timestamp":"2024-01-01T12:00:05.000Z","uuid":"msg-asst-1","parentUuid":"msg-user-1","sessionId":"sess-abc","cwd":"/tmp/demo-project","message":{"role":"assistant","model":"claude-sonnet-4","content":[{"type":"text","text":"This function returns the sum."},{"type":"tool_use","name":"Bash","input":{}}],"usage":{"input_tokens":120,"output_tokens":45}}}
+{"type":"file-history-snapshot","timestamp":"2024-01-01T12:00:10.000Z","uuid":"snap-1","sessionId":"sess-abc","message":{"role":"system","content":[]}}

--- a/tests/fixtures/ai-history/claude-subagents/.claude/projects/demo/main/sess-main.jsonl
+++ b/tests/fixtures/ai-history/claude-subagents/.claude/projects/demo/main/sess-main.jsonl
@@ -1,0 +1,1 @@
+{"type":"user","timestamp":"2024-01-01T12:00:00.000Z","uuid":"u1","sessionId":"main-1","message":{"role":"user","content":[{"type":"text","text":"main thread"}]}}

--- a/tests/fixtures/ai-history/claude-subagents/.claude/projects/demo/subagents/agent-a/sess-sub.jsonl
+++ b/tests/fixtures/ai-history/claude-subagents/.claude/projects/demo/subagents/agent-a/sess-sub.jsonl
@@ -1,0 +1,1 @@
+{"type":"user","timestamp":"2024-01-01T12:01:00.000Z","uuid":"u2","sessionId":"sub-1","message":{"role":"user","content":[{"type":"text","text":"subagent thread"}]}}

--- a/tests/fixtures/ai-history/claude/.claude/history.jsonl
+++ b/tests/fixtures/ai-history/claude/.claude/history.jsonl
@@ -1,0 +1,2 @@
+{"display":"How do I list running processes?","timestamp":1704067200000,"sessionId":"sess-history-1","project":"/tmp/demo-project"}
+{"display":"","timestamp":1704067300000,"sessionId":"sess-empty","project":"/tmp/demo-project"}

--- a/tests/fixtures/ai-history/claude/.claude/projects/demo-app/sess-abc.jsonl
+++ b/tests/fixtures/ai-history/claude/.claude/projects/demo-app/sess-abc.jsonl
@@ -1,0 +1,3 @@
+{"type":"user","timestamp":"2024-01-01T12:00:00.000Z","uuid":"msg-user-1","parentUuid":"","sessionId":"sess-abc","cwd":"/tmp/demo-project","message":{"role":"user","content":[{"type":"text","text":"Explain this function"}]}}
+{"type":"assistant","timestamp":"2024-01-01T12:00:05.000Z","uuid":"msg-asst-1","parentUuid":"msg-user-1","sessionId":"sess-abc","cwd":"/tmp/demo-project","message":{"role":"assistant","model":"claude-sonnet-4","content":[{"type":"text","text":"This function returns the sum."},{"type":"tool_use","name":"Bash","input":{}}],"usage":{"input_tokens":120,"output_tokens":45}}}
+{"type":"file-history-snapshot","timestamp":"2024-01-01T12:00:10.000Z","uuid":"snap-1","sessionId":"sess-abc","message":{"role":"system","content":[]}}


### PR DESCRIPTION
## Summary

- track synthetic Claude fixture artifacts that were excluded by the global `.claude/` ignore rule
- initialize SQLite query metadata and preserve timestamp distinct semantics
- update SQLite tests for the bounded response contract and guaranteed cleanup
- cap the release test step at 10 minutes

## Validation

- fresh checkout: 1,207 tests passed, 0 failed, 0 skipped
- renderer production build passed
- documentation build passed

The first v1.0.8 workflow run was cancelled at the test gate before packaging; no release assets were published.