### PR TITLE
Use S3-compatible range requests for macOS updates

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -200,6 +200,7 @@ jobs:
           zip_path="$(find release -maxdepth 1 -type f -name "*${pkg_version}*.zip" | sort | head -n 1)"
           dmg_blockmap="${dmg_path}.blockmap"
           zip_blockmap="${zip_path}.blockmap"
+          app_update_yml="$(find release -type f -path "*/Contents/Resources/app-update.yml" | sort | head -n 1)"
 
           if [ "${channel}" = "latest" ]; then
             yml_name="latest-mac.yml"
@@ -212,12 +213,17 @@ jobs:
             yml_path="$(find release -maxdepth 1 -type f -name '*-mac.yml' | sort | head -n 1)"
           fi
 
-          for path_name in dmg_path zip_path dmg_blockmap zip_blockmap yml_path; do
+          for path_name in dmg_path zip_path dmg_blockmap zip_blockmap app_update_yml yml_path; do
             if [ -z "${!path_name:-}" ] || [ ! -f "${!path_name}" ]; then
               echo "::error::Missing expected release artifact: ${path_name}"
               exit 1
             fi
           done
+
+          if ! grep -Eq '^useMultipleRangeRequest:[[:space:]]*false$' "${app_update_yml}"; then
+            echo "::error::Packaged updater is not configured for S3-compatible single-range downloads"
+            exit 1
+          fi
 
           echo "dmg=${dmg_path}" >> "${GITHUB_OUTPUT}"
           echo "zip=${zip_path}" >> "${GITHUB_OUTPUT}"

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -88,6 +88,10 @@ if (updateBaseUrl) {
       provider: "generic",
       url: updateBaseUrl,
       channel: updateChannel,
+      // AWS S3 supports a single byte range per GET request. The regional
+      // virtual-hosted URL does not match electron-updater's built-in
+      // s3.amazonaws.com heuristic, so disable multipart ranges explicitly.
+      useMultipleRangeRequest: false,
     },
   ];
 }


### PR DESCRIPTION
## Summary
- disable multipart range requests in the packaged generic updater configuration
- add a release gate that verifies the built app-update.yml contains the single-range setting

## Why
The repaired blockmaps are now downloaded successfully and electron-updater computes the expected delta. AWS S3 regional virtual-hosted endpoints support single byte ranges but not the multipart range response expected by electron-updater's default generic-provider mode, causing a full-download fallback.

## Validation
- electron-builder configuration schema validation passed
- publish configuration resolves useMultipleRangeRequest=false
- release workflow YAML parsed successfully
- existing test suite remains at 0 failures from PR #19 validation