### PR TITLE
Docs: publish v1.0.8 AI application forensics update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to IRFlow Timeline. The macOS release workflow
 released version as the GitHub release notes — keep version headers in the form
 `## v<MAJOR.MINOR.PATCH>`.
 
+## v1.0.8
+
+IRFlow Timeline 1.0.8 significantly expands **AI application forensics**, adding deeper artifact collection and parsing across popular AI assistants.
+
+### AI Application Forensics
+
+- **Grok Build support (new)** — collect and analyze Grok AI prompts, responses, reasoning, exact terminal commands, tool results, session context, and file-change records.
+- **Claude expanded** — recursively parse Claude Code and Claude Desktop/Cowork sessions, transcripts, audit records, tool activity, and actual shell commands.
+- **Codex expanded** — recover versioned SQLite data with WAL/SHM support, dated rollout sessions, commands, tool calls, and bounded outputs.
+- Improved parsing for ChatGPT Desktop, GitHub Copilot CLI, Gemini CLI, Cursor, and other supported assistants.
+- Better provenance, session relationships, and AI Secret Hunt safeguards.
+
+### Additional Improvements
+
+- New guided workflow for importing KAPE and triage collections.
+- Enhanced Process Inspector, Persistence Analyzer, and Lateral Movement Tracker.
+- Improved timeline navigation, bulk actions, and evidence review.
+- Memory-safe queries and bounded workers for greater stability with large datasets.
+- Signed and notarized universal macOS release for Apple Silicon and Intel.
+
 ## v1.0.7
 
 Brings **AI assistant query history** into the timeline as a first-class forensic artifact: collect it from a host or triage package, normalize every tool into one tab, and **hunt for secrets that were leaked into AI chats** — passwords, API keys, tokens, and private keys.

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitepress'
 
 export default defineConfig({
   title: 'IRFlow Timeline',
-  description: 'Native macOS DFIR timeline analysis — EVTX, CSV, XLSX, Plaso, $MFT, $J, and local AI app artifacts with AI Secret Hunt and built-in investigation analytics',
+  description: 'Native macOS DFIR timeline analysis with expanded AI application forensics for Grok Build, Claude, Codex, ChatGPT, Copilot, Gemini, Cursor, and more',
   base: '/irflow-timeline/',
   lastUpdated: true,
   cleanUrls: true,
@@ -17,23 +17,25 @@ export default defineConfig({
   head: [
     ['link', { rel: 'icon', type: 'image/svg+xml', href: '/irflow-timeline/logo.svg' }],
     ['meta', { property: 'og:title', content: 'IRFlow Timeline' }],
-    ['meta', { property: 'og:description', content: 'Native macOS DFIR timeline analysis — EVTX, CSV, XLSX, Plaso, $MFT, $J, and local AI app artifacts with AI Secret Hunt and built-in investigation analytics' }],
+    ['meta', { property: 'og:description', content: 'IRFlow Timeline 1.0.8 expands AI application forensics with Grok Build, deeper Claude and Codex evidence, and collection-scale DFIR workflows.' }],
     ['meta', { property: 'og:image', content: 'https://r3nzsec.github.io/irflow-timeline/IRFlow-Timeline-Home.png' }],
     ['meta', { property: 'og:type', content: 'website' }],
     ['meta', { property: 'og:url', content: 'https://r3nzsec.github.io/irflow-timeline/' }],
     ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
     ['meta', { name: 'twitter:title', content: 'IRFlow Timeline' }],
-    ['meta', { name: 'twitter:description', content: 'Native macOS DFIR timeline analysis — EVTX, CSV, XLSX, Plaso, $MFT, $J, and local AI app artifacts with AI Secret Hunt and built-in investigation analytics' }],
+    ['meta', { name: 'twitter:description', content: 'IRFlow Timeline 1.0.8 expands AI application forensics with Grok Build, deeper Claude and Codex evidence, and collection-scale DFIR workflows.' }],
     ['meta', { name: 'twitter:image', content: 'https://r3nzsec.github.io/irflow-timeline/IRFlow-Timeline-Home.png' }],
     ['script', { 'data-goatcounter': 'https://irflowtimeline.goatcounter.com/count', async: '', src: '//gc.zgo.at/count.js' }],
     ['script', { type: 'application/ld+json' }, JSON.stringify({
       '@context': 'https://schema.org',
       '@type': 'SoftwareApplication',
       name: 'IRFlow Timeline',
-      description: 'Native macOS DFIR timeline analysis for EVTX, CSV, XLSX, Plaso, $MFT, $J, and local AI assistant artifacts — with AI Secret Hunt and SQLite-backed investigation analytics.',
+      description: 'Native macOS DFIR timeline analysis with local AI application forensics for Grok Build, Claude, Codex, ChatGPT, Copilot, Gemini, Cursor, and other assistants.',
+      softwareVersion: '1.0.8',
       operatingSystem: 'macOS',
       applicationCategory: 'SecurityApplication',
       url: 'https://r3nzsec.github.io/irflow-timeline/',
+      downloadUrl: 'https://github.com/r3nzsec/irflow-timeline/releases/tag/v1.0.8',
       author: {
         '@type': 'Person',
         name: 'Renzon Cruz',
@@ -55,11 +57,13 @@ export default defineConfig({
       { text: 'Features', link: '/features/virtual-grid' },
       { text: 'Workflows', link: '/workflows/kape-integration' },
       { text: 'DFIR Tips', link: '/dfir-tips/ransomware-investigation' },
+      { text: 'Blog', link: '/blog/' },
       { text: 'Reference', link: '/reference/keyboard-shortcuts' },
       { text: 'Author', link: '/about/author' },
       {
-        text: 'v1.0.7',
+        text: 'v1.0.8',
         items: [
+          { text: 'What’s New in v1.0.8', link: '/blog/v1.0.8-ai-application-forensics' },
           { text: 'Changelog', link: '/about/changelog' },
           { text: 'Roadmap', link: '/about/roadmap' },
           { text: 'Credits', link: '/about/credits' }
@@ -151,6 +155,15 @@ export default defineConfig({
             { text: 'KAPE Triage Workflow', link: '/dfir-tips/kape-triage-workflow' },
             { text: 'Threat Intel IOC Sweeps', link: '/dfir-tips/threat-intel-ioc-sweeps' },
             { text: 'Building the Final Report', link: '/dfir-tips/building-final-report' }
+          ]
+        }
+      ],
+      '/blog/': [
+        {
+          text: 'IRFlow Timeline Blog',
+          items: [
+            { text: 'All Posts', link: '/blog/' },
+            { text: 'v1.0.8 — AI Application Forensics', link: '/blog/v1.0.8-ai-application-forensics' }
           ]
         }
       ],

--- a/docs/.vitepress/theme/HeroAiAppIcon.vue
+++ b/docs/.vitepress/theme/HeroAiAppIcon.vue
@@ -15,6 +15,13 @@
       <path fill="none" :stroke="brand.codex" stroke-width="2" stroke-linecap="round" d="M12.9 16.1h3.6" />
     </g>
 
+    <!-- Grok Build -->
+    <g v-else-if="id === 'grok'">
+      <circle cx="12" cy="12" r="10" fill="#050505" />
+      <path fill="#fff" d="M17.55 5.72a8.18 8.18 0 0 0-10.7-.15 8.17 8.17 0 0 0-.94 11.56l1.66-1.55a5.92 5.92 0 0 1 .78-8.29 5.91 5.91 0 0 1 7.56-.12l1.64-1.45Z" />
+      <path fill="#fff" d="m3.24 20.76 11.64-9.98c.46-.39 1.15-.24 1.4.31a5.92 5.92 0 0 1-8.75 7.35l-1.66 1.55a8.18 8.18 0 0 0 12.21-10.7L21.2 2.8 10.68 14.6l-7.44 6.16Z" />
+    </g>
+
     <!-- ChatGPT Desktop -->
     <g v-else-if="id === 'chatgpt'">
       <circle cx="12" cy="12" r="10" :fill="tones(brand.openai).soft" />

--- a/docs/.vitepress/theme/HeroAiAppsGraphic.vue
+++ b/docs/.vitepress/theme/HeroAiAppsGraphic.vue
@@ -29,7 +29,7 @@
       <!-- Header -->
       <text x="24" y="24" fill="#777" font-size="8" font-family="'JetBrains Mono', monospace" letter-spacing="1.4">AI APPS SCAN</text>
       <rect x="224" y="10" width="52" height="18" rx="3" fill="#E85D2A18" stroke="#E85D2A" stroke-width="0.7" stroke-opacity="0.55" />
-      <text x="250" y="22" fill="#E85D2A" font-size="7" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="700">8 APPS</text>
+      <text x="250" y="22" fill="#E85D2A" font-size="7" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="700">{{ apps.length }} APPS</text>
 
       <!-- Scan rays + flowing packets -->
       <g v-for="(app, i) in apps" :key="'r' + i">

--- a/docs/.vitepress/theme/HeroGraphic.vue
+++ b/docs/.vitepress/theme/HeroGraphic.vue
@@ -20,7 +20,7 @@
       </div>
       <div class="title-right">
         <span class="brand-name">IRFlow</span>
-        <span class="brand-version">v1.0.7</span>
+        <span class="brand-version">v1.0.8</span>
       </div>
     </div>
 
@@ -111,7 +111,7 @@
         <div class="panel ai-apps-panel" :class="{ 'tour-focus': tourStep === 4 }" :style="{ opacity: sectionOpacity(4, showAiApps), transform: showAiApps ? 'translateY(0)' : 'translateY(10px)' }">
           <div class="panel-header">
             <span class="panel-title">AI APPS SCAN</span>
-            <span class="panel-badge badge-orange">8 APPS</span>
+            <span class="panel-badge badge-orange">{{ aiApps.length }} APPS</span>
           </div>
           <svg viewBox="0 0 380 140" class="ai-apps-svg" aria-hidden="true">
             <defs>
@@ -250,7 +250,7 @@ const tourSteps = [
   { index: 1, shortLabel: 'Search', icon: '\uD83D\uDD0D', caption: '5 search modes: text, regex, fuzzy, FTS, mixed' },
   { index: 2, shortLabel: 'Processes', icon: '\uD83C\uDF33', caption: 'Reconstruct attack chains with MITRE ATT&CK mapping', desktopOnly: true },
   { index: 3, shortLabel: 'Network', icon: '\uD83D\uDD17', caption: 'Track multi-hop lateral movement across your network', desktopOnly: true },
-  { index: 4, shortLabel: 'AI Apps', icon: '\uD83E\uDD16', caption: 'Collect AI history from Claude, Codex, Cursor, Copilot, ChatGPT, Gemini, Windsurf, and Continue' },
+  { index: 4, shortLabel: 'AI Apps', icon: '\uD83E\uDD16', caption: 'Collect AI history from Grok Build, Claude, Codex, ChatGPT, Copilot, Gemini, Cursor, and more' },
 ]
 
 const visibleTourSteps = computed(() => {
@@ -313,6 +313,7 @@ const maxHist = Math.max(...histogramData)
 const aiTimelineEvents = [
   { time: '2025-02-14 03:11:02', source: 'AI: Cursor', event: 'USER', detail: 'paste AWS key into agent prompt', severity: 'critical' },
   { time: '2025-02-14 03:11:18', source: 'AI: Codex', event: 'TOOL', detail: 'shell: whoami /priv', severity: 'high' },
+  { time: '2025-02-14 03:11:31', source: 'AI: Grok', event: 'TOOL', detail: 'run_terminal_command: systeminfo', severity: 'high' },
   { time: '2025-02-14 03:11:44', source: 'AI: Claude', event: 'ASST', detail: 'powershell lateral movement steps', severity: 'high' },
   { time: '2025-02-14 03:12:05', source: 'AI: Copilot', event: 'USER', detail: 'decrypt mimikatz output', severity: 'critical' },
   { time: '2025-02-14 03:12:22', source: 'AI: ChatGPT', event: 'USER', detail: 'ransomware recovery script', severity: 'medium' },
@@ -399,7 +400,7 @@ const filterTags = [
 ]
 
 const aiFilterTags = [
-  { label: 'AI Apps: 8 sources merged', color: '#E8613A' },
+  { label: 'AI Apps: 9 sources merged', color: '#E8613A' },
   { label: 'Tag: Secret Hunt', color: '#FF3B3B' },
   { label: 'Workspace: finance-api', color: '#9B59B6' },
 ]
@@ -415,6 +416,7 @@ watch(tourStep, (step) => {
 const aiApps = [
   { label: 'Claude', abbr: 'CL', color: '#D4A574', x: 42, y: 28 },
   { label: 'Codex', abbr: 'CX', color: '#10A37F', x: 42, y: 112 },
+  { label: 'Grok', abbr: 'GK', color: '#F5F5F5', x: 190, y: 16 },
   { label: 'Cursor', abbr: 'CU', color: '#6BA3E8', x: 108, y: 18 },
   { label: 'Copilot', abbr: 'CP', color: '#4A90D9', x: 108, y: 122 },
   { label: 'ChatGPT', abbr: 'GPT', color: '#74AA9C', x: 272, y: 28 },

--- a/docs/.vitepress/theme/hero-ai-apps.js
+++ b/docs/.vitepress/theme/hero-ai-apps.js
@@ -2,6 +2,7 @@
 export const heroAiApps = [
   { id: 'claude', label: 'Claude Code', lines: ['Claude Code'], color: '#D97757', x: 38, y: 84 },
   { id: 'codex', label: 'OpenAI Codex', lines: ['OpenAI', 'Codex'], color: '#2F6FED', x: 38, y: 200 },
+  { id: 'grok', label: 'Grok Build', lines: ['Grok Build'], color: '#F5F5F5', x: 150, y: 46 },
   { id: 'cursor', label: 'Cursor', lines: ['Cursor'], color: '#7d8590', x: 98, y: 62 },
   { id: 'copilot', label: 'GitHub Copilot', lines: ['GitHub', 'Copilot'], color: '#8b949e', x: 98, y: 218 },
   { id: 'chatgpt', label: 'ChatGPT Desktop', lines: ['ChatGPT', 'Desktop'], color: '#10A37F', x: 202, y: 62 },

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -4,45 +4,34 @@ description: IRFlow Timeline changelog — version history, new features, perfor
 
 # Changelog
 
-## Unreleased — Process Inspector & investigation UX
+## v1.0.8 — July 27, 2026
 
-Work in progress toward the next release. Feature pages already describe the UI; summary of the major deltas:
+### AI Application Forensics
 
-### Process Inspector
+- **Grok Build support (new)** — Parses `.grok` prompt history and session stores into AI Query History:
+  - Timestamped prompts, responses, reasoning, exact terminal-command inputs, completion output, and token usage
+  - Session/model/workspace/Git context plus file-hunk records
+  - Credential-bearing Grok configuration files are deliberately excluded from timeline text
+- **Claude expanded** — Recursively parses Claude Code projects and subagents plus Claude Desktop/Cowork session metadata, isolated transcripts, audit JSONL, tool calls, and actual shell commands
+- **Codex expanded** — Adds current/archived dated rollouts and version-aware `state*.sqlite` discovery; snapshots SQLite with WAL/SHM companions to preserve recent thread, spawn-edge, and dynamic-tool metadata
+- **Modernized AI evidence model** — Preserves `InvokedTool`, exact `ToolCommand`, structured `ToolInput`, descriptions, and bounded tool results across modern JSONL formats
+- **Broader app coverage** — Improves ChatGPT Desktop, GitHub Copilot CLI and VS Code, Gemini CLI, Cursor, Windsurf, and Continue extraction
+- **AI Secret Hunt safeguards** — Sensitive-value reveal now uses the managed confirmation workflow
 
-- **Verdict-first results** — severity hero with counts, top stories, ATT&CK chips, link quality, and telemetry completeness after every build
-- **Story / Triage / Hunt / Graph / Raw** view modes — investigation stories, chain clusters, spatial multi-host graph, and full tree
-- **Rules health report** — coverage of fired / silent / disabled built-in rules, custom rules, and multi-stage sequences; copy or download plain-text report
-- **Async chunked scoring** — detection scoring no longer blocks the UI on large trees; progress in the hero
-- **Filter Grid pivot** — one click from a process applies ProcessGuid (or host+PID) ± time window and scrolls to the create event
-- **Cross-feature handoffs** — Open Lateral Movement / Persistence / Sigma around the selected process (host + time window)
-- **Enrichment passes** — terminate (5/4689), process access (10), privilege use (4673/4674), network (3), DNS (22), image load (7), file create (11)
-- **Grandparent chains (pi-60)** and expanded standalone catalog (~60 `pi-*` rules), gated interpreter chains, prevalence, allowlist dampening
-- **Scoped rebuild** when the process limit truncates — re-run for a host and/or time window without raising the global max
-- **Modal architecture** — config / loading / results phases split for maintainability; keyboard navigation in the tree
+### Collection and Investigation Workflows
 
-### File & grid UX
+- **Open Triage Collection** — Inventory KAPE/triage folders, attribute artifacts to likely hosts, choose import lanes, and optionally hand EVTX to Sigma analysis
+- **Process Inspector overhaul** — Verdict-first results, Story/Triage/Hunt/Graph/Raw modes, rule-health coverage, enrichment passes, Filter Grid pivots, and cross-analyzer handoffs
+- **Persistence Analyzer** — Multi-source scanning, KAPE collection analysis, incident clustering, registry-shape hardening, and remote-origin scoring
+- **Lateral Movement Tracker** — Multi-source detection, normalized endpoints, raw Terminal Services evidence, stronger RDP scoring, graph layout, campaign triage, and stage isolation
+- **Timeline workflow** — Command palette, keyboard navigation, selection bar, multi-row bulk actions, and grid/filter polish
 
-- **Open Triage Collection** — point at a KAPE/triage folder; review what is present, import LM-relevant EVTX (and other ingestible artifacts), optional Sigma handoff; unparsed artifact kinds surface tool hints (e.g. PECmd for Prefetch) instead of silent drops
-- **Command palette** — `Cmd+K` searchable actions across File / View / Actions / Tools / Help
-- **Selection bar** — compact strip for multi-row selection with copy, bulk actions, and clear
-- Keyboard and filter-bar polish (command palette active-descendant pattern, responsive search options)
+### Performance, Stability, and Release Quality
 
-### Persistence Analyzer
-
-- **Multi-source scan** — correlate persistence evidence across multiple open tabs
-- **Analyze KAPE Collection** — folder-level scan of KAPE outputs (EVTX + registry exports), with incident clustering and explicit “unread artifact” warnings
-- Hardened registry shape matching and remote-origin scoring for service/task installs
-
-### Lateral Movement Tracker
-
-- Detector registry for spine event IDs, safer `maxRows` clamping, multi-source budget split per tab
-- Timezone-aware scoring paths and stage isolation improvements for large multi-tab runs
-
-### Data quality
-
-- Plaso parser field-discovery and import path improvements
-- Process tree worker enrichment and link-provenance fields on export (CSV/JSON)
+- Streams heavy query results and bounds worker memory/lifecycle to prevent JavaScript heap exhaustion on large evidence sets
+- Uses bounded JSONL readers and explicit per-row evidence caps while retaining useful tool output
+- Gates macOS packaging on automated tests plus renderer and VitePress documentation builds
+- Ships as a signed and notarized universal macOS release for Apple Silicon and Intel
 
 ---
 

--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -10,14 +10,6 @@ This page outlines the planned direction for IRFlow Timeline. Priorities may shi
 
 ## In Progress
 
-### Process Inspector depth (next release)
-- Verdict hero, Story / Graph / Raw modes, **Rules** health coverage report, Filter Grid pivots, and Lateral/Persistence/Sigma handoffs — see [Process Inspector](/features/process-tree) and the [changelog Unreleased](/about/changelog) section
-- Further rule-catalog expansion and analyst-facing coverage tooling
-
-### Open Triage Collection & multi-source analyzers
-- Folder-level KAPE/triage inventory with LM and Sigma lanes
-- Persistence multi-source + **Analyze KAPE Collection**; Lateral Movement multi-source budget and detector registry hardening
-
 ### Enhanced Detection Rules
 - Expand the detection rules library beyond the current ones
 - Community-contributed rule packs with shared rule repositories
@@ -40,7 +32,7 @@ This page outlines the planned direction for IRFlow Timeline. Priorities may shi
 - Real-time collaborative analysis for team-based investigations
 
 ### AI-Assisted Analysis (LLM — planned)
-- **Not the same as v1.0.7 AI Artifacts** — local AI history collection and **AI Secret Hunt** already ship today; see [AI Artifacts](/features/ai-artifacts) and [AI Query History](/dfir-tips/ai-query-history)
+- **Not the same as v1.0.8 AI Artifacts** — local AI history collection, Grok Build parsing, and **AI Secret Hunt** already ship today; see [AI Artifacts](/features/ai-artifacts) and [AI Query History](/dfir-tips/ai-query-history)
 - LLM-powered summarization of tagged findings for report drafting
 - Natural language queries against timeline data ("show me all lateral movement after 3 AM")
 - Anomaly detection suggestions based on statistical patterns
@@ -63,8 +55,9 @@ This page outlines the planned direction for IRFlow Timeline. Priorities may shi
 
 See the [Changelog](/about/changelog) for detailed release notes on everything shipped so far. Highlights from recent releases:
 
-- **Process Inspector investigation UX (unreleased / in tree)** — multi-pass enrichment, async scoring, Story/Graph views, rule health report, Filter Grid, cross-analyzer handoffs
-- **AI Artifacts (v1.0.7)** — **Collect AI Artifacts** merges local assistant stores (Claude, Codex, ChatGPT Desktop, Gemini CLI, Cursor, Copilot, Windsurf, Continue) into one **AI Query History** tab from this Mac or KAPE/triage folders; **AI Secret Hunt** finds exposed keys, tokens, and credentials with redacted-by-default triage and exportable exposure briefs
+- **AI Application Forensics (v1.0.8)** — adds Grok Build; recursive Claude Desktop/Cowork transcripts and audits; Codex SQLite/WAL/SHM recovery; and exact, bounded tool-command evidence across supported assistants
+- **Collection-scale investigation (v1.0.8)** — ships Open Triage Collection, the Process Inspector Story/Graph/Raw overhaul, multi-source Persistence analysis, and stronger Lateral Movement detection and evidence triage
+- **AI Artifacts and AI Secret Hunt (v1.0.7)** — introduced the unified **AI Query History** tab and redacted-by-default secret-exposure triage
 - **Sigma Detection** — Dual JS Sigma + Hayabusa engine scanning raw EVTX, EvtxECmd output, and imported timelines, with custom rule collections, MITRE ATT&CK mapping, a triage dashboard, noisy-rule suppression, and persistent scan history
 - **RDP Bitmap Cache** — ANSSI-FR `bmc-tools` integration to recover bitmap tiles from `bcache*.bmc` / `cache????.bin` artifacts with an exportable, hashed evidence package
 - **Lateral Movement expansion** — Accounts and Exec Sessions tabs, pair-based Incidents, multi-hop Campaign clustering, and a Telemetry Coverage panel

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -1,0 +1,16 @@
+---
+description: IRFlow Timeline release announcements, feature deep dives, and digital forensics workflow updates.
+---
+
+# IRFlow Timeline Blog
+
+Release announcements and focused notes about new forensic workflows.
+
+## Latest
+
+### [IRFlow Timeline 1.0.8 — AI Application Forensics Expanded](/blog/v1.0.8-ai-application-forensics)
+
+**July 27, 2026**
+
+Grok Build support, deeper Claude Desktop/Cowork and Codex recovery, exact AI tool-command evidence, collection-scale triage, and major Process Inspector improvements.
+

--- a/docs/blog/v1.0.8-ai-application-forensics.md
+++ b/docs/blog/v1.0.8-ai-application-forensics.md
@@ -1,0 +1,44 @@
+---
+title: IRFlow Timeline 1.0.8 — AI Application Forensics Expanded
+description: IRFlow Timeline 1.0.8 adds Grok Build support, deeper Claude and Codex evidence recovery, exact AI tool commands, and collection-scale DFIR workflows.
+---
+
+# IRFlow Timeline 1.0.8 — AI Application Forensics Expanded
+
+**Published July 27, 2026**
+
+IRFlow Timeline 1.0.8 significantly expands **AI application forensics**. Investigators can now recover more local AI-native evidence, preserve the commands and tools used by coding agents, and correlate that activity with the rest of an endpoint timeline.
+
+## Grok Build support
+
+**[Grok Build](https://github.com/xai-org/grok-build) is a new native evidence source in v1.0.8.** IRFlow parses the local `.grok` session store into the same AI Query History schema used by other assistants.
+
+The parser recovers:
+
+- Timestamped prompts, assistant responses, and reasoning records
+- Direct shell entries and exact `run_terminal_command` inputs
+- Completion status, working directory, exit code, and bounded terminal output
+- Session, model, workspace, Git, sandbox, and token metadata
+- File-hunk records showing paths and added or removed lines
+
+IRFlow deliberately excludes Grok credential files such as `auth.json` and `mcp_credentials.json` from timeline text. Consumer Grok web/mobile conversations are also separate from Grok Build and require browser-origin evidence or a vendor export.
+
+## Deeper Claude and Codex evidence
+
+- **Claude Code and Claude Desktop/Cowork** — recursively parses project and subagent sessions, isolated Cowork transcripts, audit records, tool calls, and actual shell commands.
+- **OpenAI Codex** — parses dated and archived rollout JSONL plus versioned `state*.sqlite` stores. WAL/SHM companions are acquired with the database so recent thread, spawn-edge, and dynamic-tool metadata is not silently missed.
+- **Modern tool evidence** — exact commands, structured tool inputs, descriptions, and useful tool results are retained with explicit size caps for stability.
+- **Broader coverage** — parsing is also improved for ChatGPT Desktop, GitHub Copilot CLI and VS Code, Gemini CLI, Cursor, Windsurf, and Continue.
+
+## More than AI artifacts
+
+Version 1.0.8 also adds **Open Triage Collection**, upgrades Process Inspector with Story/Graph/Raw investigation modes and rule-health context, and strengthens multi-source Persistence and Lateral Movement analysis.
+
+Large queries and background jobs now use bounded workers, cancellable lifecycles, and streamed results to reduce Electron memory pressure on large collections.
+
+## Get v1.0.8
+
+- [Download IRFlow Timeline 1.0.8](https://github.com/r3nzsec/irflow-timeline/releases/tag/v1.0.8)
+- [AI Artifacts overview](/features/ai-artifacts)
+- [AI artifact paths and forensic coverage](/dfir-tips/ai-query-history)
+- [Full changelog](/about/changelog)

--- a/docs/dfir-tips/ai-query-history.md
+++ b/docs/dfir-tips/ai-query-history.md
@@ -1,8 +1,16 @@
+---
+description: Forensic artifact paths and parsing coverage for Grok Build, Claude, Codex, ChatGPT, Copilot, Gemini, Cursor, Windsurf, Continue, and other local AI applications.
+---
+
 # AI Query History and AI App Artifacts
 
 IRFlow Timeline includes a native **AI Query History** extractor for investigating local AI assistant usage during incident response. It parses local desktop, CLI, and editor-assistant stores into one timeline so analysts can review prompts, responses, tool calls, workspaces, source files, and possible pasted secrets.
 
 For the feature-level overview, see [AI Artifacts](/features/ai-artifacts). This guide is the deeper artifact inventory and investigation workflow.
+
+::: tip v1.0.8 coverage
+The v1.0.8 parser expansion adds **Grok Build**, recursive **Claude Desktop/Cowork** transcripts and audit records, versioned **Codex** SQLite recovery with WAL/SHM companions, and exact `ToolCommand`/structured `ToolInput` preservation across modern JSONL formats.
+:::
 
 ## AI History vs AI Prompts
 
@@ -141,9 +149,9 @@ ChatGPT stores vary by version:
 
 The macOS **Codex** app in `~/Library/Application Support/Codex` is UI cache only; forensic content is under **`~/.codex`**.
 
-### Grok Build (official terminal agent)
+### Grok Build (Grok AI terminal agent)
 
-[Grok Build](https://github.com/xai-org/grok-build) is xAI's official terminal coding agent. Its default data root is `~/.grok`; `GROK_HOME` can override that location. The official [authentication guide](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/02-authentication.md) documents `~/.grok/auth.json` and `~/.grok/mcp_credentials.json`, both of which should be treated as credential-bearing evidence.
+[Grok Build](https://github.com/xai-org/grok-build) is the terminal coding agent distributed as the `grok` CLI. Its default data root is `~/.grok`; `GROK_HOME` can override that location. The upstream [authentication guide](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/02-authentication.md) documents `~/.grok/auth.json` and `~/.grok/mcp_credentials.json`, both of which should be treated as credential-bearing evidence.
 
 | Artifact | Forensic value |
 |----------|----------------|

--- a/docs/features/ai-artifacts.md
+++ b/docs/features/ai-artifacts.md
@@ -8,6 +8,10 @@ AI Artifacts turns local AI assistant history into timeline evidence. It helps i
 
 The feature creates an **AI Query History** timeline tab from local desktop, CLI, and editor-assistant stores. Each row keeps the evidence context analysts need: timestamp, role, AI app, invoked action, session, workspace, source file, summary, full text, and endpoint attribution when available.
 
+::: tip Expanded in v1.0.8
+**Grok Build is now a native evidence source.** IRFlow also adds recursive Claude Desktop/Cowork transcript and audit parsing, version-aware Codex SQLite discovery with WAL/SHM acquisition, and bounded JSONL/tool evidence that preserves exact shell commands without allowing one oversized record to exhaust Electron memory.
+:::
+
 ## Opening AI Artifacts
 
 - **Menu:** **Tools → Analysis → AI Artifacts → Collect AI Artifacts**

--- a/docs/getting-started/architecture.md
+++ b/docs/getting-started/architecture.md
@@ -6,7 +6,7 @@ description: IRFlow Timeline architecture — React renderer, Electron main proc
 
 Technical overview of IRFlow Timeline's architecture for developers and contributors.
 
-> **v1.0.6+ modular layout (current: v1.0.7).** What was once a ~20K-line `App.jsx` and monolithic `electron/parser.js` / `electron/db.js` is now decomposed into ~200 focused modules across the renderer and main process (`parsers/`, `ipc/`, `jobs/`, `analyzers/`, and related trees). v1.0.7 adds **`parsers/ai-history/`** and AI artifact IPC for **Collect AI Artifacts** and **AI Secret Hunt**. The file references below reflect that layout.
+> **v1.0.6+ modular layout (current: v1.0.8).** What was once a ~20K-line `App.jsx` and monolithic `electron/parser.js` / `electron/db.js` is now decomposed into focused modules across the renderer and main process (`parsers/`, `ipc/`, `jobs/`, `analyzers/`, and related trees). v1.0.8 extends the AI parser subsystem, triage collection orchestration, worker lifecycle controls, and multi-source analyzers. The file references below reflect that layout.
 
 ## System Architecture
 
@@ -44,7 +44,7 @@ Responsibilities: grid rendering with virtual scrolling, user-interaction handli
 
 The preload script creates a secure bridge between renderer and main using Electron's `contextBridge`. It exposes a **whitelisted `window.tle` API** with `contextIsolation` enabled and `nodeIntegration` disabled. All renderer↔main calls go through here as invoke-only channels; listener registrations return unsubscribe functions. Channels cover file ops, queries, tag/bookmark ops, IOC/VirusTotal enrichment, analysis (NTFS, lateral movement, Sigma, RDP bitmap cache), jobs, session persistence, filter presets, and auto-update.
 
-**v1.0.7 AI Artifacts / Secret Hunt surface** (same invoke-only pattern):
+**v1.0.8 AI Artifacts / Secret Hunt surface** (same invoke-only pattern):
 
 | `window.tle` method | IPC channel | Purpose |
 |---------------------|-------------|---------|
@@ -145,7 +145,7 @@ Streaming parsers convert source files into batched SQLite inserts:
 - **`plaso.js`** — Plaso SQLite databases via ATTACH + zlib
 - **`mft.js`** — two-pass raw `$MFT` parser (pass 1 builds directory + FN attribute maps, pass 2 reconstructs full paths); outputs **34 columns** matching MFTECmd, with SI-vs-FN timestamp comparison and resident-data detection
 - **`usn.js`** — raw `$UsnJrnl:$J` parser with reason-flag decoding and file-reference extraction
-- **`ai-history/`** — per-app parsers (Claude, Codex, ChatGPT, Gemini CLI, Cursor, Copilot, Windsurf, Continue) merged by profile scan or folder import into **AI Query History** tabs
+- **`ai-history/`** — per-app parsers (Claude Code/Desktop/Cowork, Codex, Grok Build, ChatGPT, Gemini CLI, Cursor, Copilot, Windsurf, Continue) merged by profile scan or folder import into **AI Query History** tabs. JSONL is streamed with bounded line and evidence sizes; SQLite sources are snapshotted with available WAL/SHM companions.
 
 ## Data Flow
 
@@ -163,7 +163,7 @@ open → main.enqueueImport() → import-worker (parsers/index.js, streaming)
 4. On completion the main process adopts the worker's DB; the initial row window + metadata go to the renderer.
 5. After the queue drains, `index-worker` builds column indexes, then the FTS5 index, in the background (`index-progress` / `fts-progress`).
 
-### AI Artifacts Pipeline (v1.0.7)
+### AI Artifacts Pipeline (v1.0.8)
 
 ```
 Collect AI Artifacts → discover-ai-history-profile (main)

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,12 +47,13 @@ features:
     details: Bookmarks, color-coded tags, conditional formatting with KAPE-aware presets, and full session save/restore.
 ---
 
-## What's New · v1.0.7
+## What's New · v1.0.8
 
-- **AI Artifacts** — Collect local assistant history into one **AI Query History** tab; **AI Secret Hunt** for redacted secret exposure
-- **Process Inspector (ongoing)** — Story / Graph / Raw views, verdict hero, Filter Grid pivots, cross-feature handoffs, and a **Rules** health report — see [Process Inspector](/features/process-tree)
+- **Grok Build support (new)** — Parse Grok AI prompts, responses, reasoning, exact terminal commands, completion output, session metadata, and file-change hunks.
+- **Expanded AI application forensics** — Deeper Claude Desktop/Cowork transcripts and audit trails, Codex SQLite recovery with WAL/SHM, and bounded tool evidence across supported assistants.
+- **Collection-scale investigations** — Open KAPE/triage collections and pivot through the upgraded Process Inspector, Persistence Analyzer, and Lateral Movement Tracker.
 
-[Full changelog →](/about/changelog)
+[Read the v1.0.8 announcement →](/blog/v1.0.8-ai-application-forensics) · [Full changelog →](/about/changelog)
 
 ## What is IRFlow Timeline?
 

--- a/docs/public/dfir-tips/Architecture-Diagram.svg
+++ b/docs/public/dfir-tips/Architecture-Diagram.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 1190" role="img" aria-labelledby="title desc">
   <title id="title">IRFlow Timeline current architecture</title>
-  <desc id="desc">IRFlow Timeline v1.0.7 architecture with a semantic color system: orange = UI/output surface, violet = secure IPC bridge, blue = orchestration and network, amber = ingestion and compute, green = data and persistence, red = forensic detection. Shows the React renderer, preload bridge, Electron main services with grouped IPC, a worker-thread pool, the SQLite data engine with analyzers (including AI history parsers and AI Secret Hunt), the dual Sigma/Hayabusa detection engine, streaming parsers, and side connectors for evidence, external tools, network, state, and outputs.</desc>
+  <desc id="desc">IRFlow Timeline v1.0.8 architecture with a semantic color system: orange = UI/output surface, violet = secure IPC bridge, blue = orchestration and network, amber = ingestion and compute, green = data and persistence, red = forensic detection. Shows the React renderer, preload bridge, Electron main services with grouped IPC, a worker-thread pool, the SQLite data engine with analyzers (including AI history parsers and AI Secret Hunt), the dual Sigma/Hayabusa detection engine, streaming parsers, and side connectors for evidence, external tools, network, state, and outputs.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0%" stop-color="#0b1016"/>
@@ -76,9 +76,9 @@
   <circle cx="140" cy="1090" r="200" fill="rgba(232,93,42,0.035)"/>
 
   <text x="220" y="56" class="title">IRFlow Timeline Architecture</text>
-  <text x="220" y="82" class="subtitle">Modular v1.0.7 codebase — ~200 focused renderer + main-process modules.</text>
+  <text x="220" y="82" class="subtitle">Modular v1.0.8 codebase — focused renderer + main-process modules.</text>
   <rect x="220" y="96" width="190" height="24" class="badge"/>
-  <text x="315" y="112" text-anchor="middle" class="tiny">v1.0.7 workspace snapshot</text>
+  <text x="315" y="112" text-anchor="middle" class="tiny">v1.0.8 workspace snapshot</text>
 
   <!-- ============ LEFT SIDE BOXES ============ -->
   <rect x="40" y="150" width="152" height="212" class="side" stroke="#d29922" stroke-opacity="0.55" filter="url(#shadow)"/>


### PR DESCRIPTION
## Summary

- publish the v1.0.8 release announcement and changelog
- emphasize new Grok Build artifact parsing and expanded Claude/Codex recovery
- update homepage, navigation, architecture, roadmap, metadata, and AI diagrams
- preserve a v1.0.8 root changelog section for future release workflow reruns

## Validation

- npm run docs:build
- npm test: 1,240 tests; 1,190 passed, 50 expected native-SQLite skips, 0 failures
- changed preview routes returned HTTP 200