### PR TITLE
Release v1.0.9: fix large EVTX imports beyond 2 GiB

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -9,11 +9,11 @@ on:
       from_tag:
         description: "Previous release tag whose ZIP blockmap must remain available"
         required: true
-        default: "v1.0.7"
+        default: "v1.0.8"
       to_tag:
         description: "Current release tag whose ZIP blockmap must be published"
         required: true
-        default: "v1.0.8"
+        default: "v1.0.9"
 
 permissions:
   contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to IRFlow Timeline. The macOS release workflow
 released version as the GitHub release notes — keep version headers in the form
 `## v<MAJOR.MINOR.PATCH>`.
 
+## v1.0.9
+
+IRFlow Timeline 1.0.9 is a focused reliability patch for large Windows Event Log investigations.
+
+### Large EVTX Imports
+
+- **Issue #22 fixed** — Raw EVTX files are no longer opened through Node's whole-file `readFile()` path, removing the 2 GiB Buffer ceiling that rejected large `Security.evtx` files before the first record was parsed.
+- **Bounded native chunk parsing** — Reads the 4 KiB EVTX header once, then processes one native 64 KiB EVTX chunk at a time instead of retaining the complete source file in memory.
+- **Approximately 4 GiB EVTX support** — Handles logs up to the EVTX format's 65,535-chunk limit, including the reported 4,109,438,976-byte (~3.83 GiB) file.
+- **Accurate large-file progress** — Progress now follows physical EVTX chunk offsets rather than record-local offsets.
+
+### Import Reliability
+
+- Duplicate requests for the same pending source are suppressed while preserving distinct workbook sheets and AI-history scopes.
+- Repeated identical import failures collapse into one actionable notification instead of filling the screen with duplicate toasts.
+- Regression coverage exercises the exact issue #22 file size and verifies that individual reads remain bounded to 64 KiB.
+
 ## v1.0.8
 
 IRFlow Timeline 1.0.8 significantly expands **AI application forensics**, adding deeper artifact collection and parsing across popular AI assistants.

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -17,13 +17,13 @@ export default defineConfig({
   head: [
     ['link', { rel: 'icon', type: 'image/svg+xml', href: '/irflow-timeline/logo.svg' }],
     ['meta', { property: 'og:title', content: 'IRFlow Timeline' }],
-    ['meta', { property: 'og:description', content: 'IRFlow Timeline 1.0.8 expands AI application forensics with Grok Build, deeper Claude and Codex evidence, and collection-scale DFIR workflows.' }],
+    ['meta', { property: 'og:description', content: 'IRFlow Timeline 1.0.9 adds bounded native chunk parsing for large EVTX files while retaining expanded AI application forensics.' }],
     ['meta', { property: 'og:image', content: 'https://r3nzsec.github.io/irflow-timeline/IRFlow-Timeline-Home.png' }],
     ['meta', { property: 'og:type', content: 'website' }],
     ['meta', { property: 'og:url', content: 'https://r3nzsec.github.io/irflow-timeline/' }],
     ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
     ['meta', { name: 'twitter:title', content: 'IRFlow Timeline' }],
-    ['meta', { name: 'twitter:description', content: 'IRFlow Timeline 1.0.8 expands AI application forensics with Grok Build, deeper Claude and Codex evidence, and collection-scale DFIR workflows.' }],
+    ['meta', { name: 'twitter:description', content: 'IRFlow Timeline 1.0.9 adds bounded native chunk parsing for large EVTX files while retaining expanded AI application forensics.' }],
     ['meta', { name: 'twitter:image', content: 'https://r3nzsec.github.io/irflow-timeline/IRFlow-Timeline-Home.png' }],
     ['script', { 'data-goatcounter': 'https://irflowtimeline.goatcounter.com/count', async: '', src: '//gc.zgo.at/count.js' }],
     ['script', { type: 'application/ld+json' }, JSON.stringify({
@@ -31,11 +31,11 @@ export default defineConfig({
       '@type': 'SoftwareApplication',
       name: 'IRFlow Timeline',
       description: 'Native macOS DFIR timeline analysis with local AI application forensics for Grok Build, Claude, Codex, ChatGPT, Copilot, Gemini, Cursor, and other assistants.',
-      softwareVersion: '1.0.8',
+      softwareVersion: '1.0.9',
       operatingSystem: 'macOS',
       applicationCategory: 'SecurityApplication',
       url: 'https://r3nzsec.github.io/irflow-timeline/',
-      downloadUrl: 'https://github.com/r3nzsec/irflow-timeline/releases/tag/v1.0.8',
+      downloadUrl: 'https://github.com/r3nzsec/irflow-timeline/releases/tag/v1.0.9',
       author: {
         '@type': 'Person',
         name: 'Renzon Cruz',
@@ -61,8 +61,9 @@ export default defineConfig({
       { text: 'Reference', link: '/reference/keyboard-shortcuts' },
       { text: 'Author', link: '/about/author' },
       {
-        text: 'v1.0.8',
+        text: 'v1.0.9',
         items: [
+          { text: 'What’s New in v1.0.9', link: '/blog/v1.0.9-large-evtx-imports' },
           { text: 'What’s New in v1.0.8', link: '/blog/v1.0.8-ai-application-forensics' },
           { text: 'Changelog', link: '/about/changelog' },
           { text: 'Roadmap', link: '/about/roadmap' },
@@ -163,6 +164,7 @@ export default defineConfig({
           text: 'IRFlow Timeline Blog',
           items: [
             { text: 'All Posts', link: '/blog/' },
+            { text: 'v1.0.9 — Large EVTX Reliability', link: '/blog/v1.0.9-large-evtx-imports' },
             { text: 'v1.0.8 — AI Application Forensics', link: '/blog/v1.0.8-ai-application-forensics' }
           ]
         }

--- a/docs/.vitepress/theme/HeroGraphic.vue
+++ b/docs/.vitepress/theme/HeroGraphic.vue
@@ -20,7 +20,7 @@
       </div>
       <div class="title-right">
         <span class="brand-name">IRFlow</span>
-        <span class="brand-version">v1.0.8</span>
+        <span class="brand-version">v1.0.9</span>
       </div>
     </div>
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -4,6 +4,21 @@ description: IRFlow Timeline changelog — version history, new features, perfor
 
 # Changelog
 
+## v1.0.9 — July 27, 2026
+
+### Large EVTX Imports
+
+- **Fixed issue #22** — Raw EVTX files no longer use Node's whole-file read path, eliminating the 2 GiB Buffer failure seen on large `Security.evtx` files
+- **Bounded 64 KiB parsing** — Reads the EVTX header once and processes one native EVTX chunk at a time, keeping memory use stable as the source grows
+- **Approximately 4 GiB support** — Supports the EVTX format's 65,535-chunk ceiling, including the reported 4,109,438,976-byte (~3.83 GiB) log
+- **Better progress reporting** — Large-file progress tracks physical chunk offsets
+
+### Import Reliability
+
+- Duplicate requests for the same pending file are suppressed without blocking distinct workbook-sheet or AI-history-scope imports
+- Repeated identical failures collapse into one retryable notification instead of stacking across the screen
+- Added an exact-size issue #22 regression plus real multi-gigabyte EVTX validation
+
 ## v1.0.8 — July 27, 2026
 
 ### AI Application Forensics

--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -55,6 +55,7 @@ This page outlines the planned direction for IRFlow Timeline. Priorities may shi
 
 See the [Changelog](/about/changelog) for detailed release notes on everything shipped so far. Highlights from recent releases:
 
+- **Large EVTX reliability (v1.0.9)** — replaces whole-file EVTX reads with bounded native 64 KiB chunk parsing, supports logs up to the format's approximately 4 GiB limit, and suppresses duplicate pending imports and repeated failure notifications
 - **AI Application Forensics (v1.0.8)** — adds Grok Build; recursive Claude Desktop/Cowork transcripts and audits; Codex SQLite/WAL/SHM recovery; and exact, bounded tool-command evidence across supported assistants
 - **Collection-scale investigation (v1.0.8)** — ships Open Triage Collection, the Process Inspector Story/Graph/Raw overhaul, multi-source Persistence analysis, and stronger Lateral Movement detection and evidence triage
 - **AI Artifacts and AI Secret Hunt (v1.0.7)** — introduced the unified **AI Query History** tab and redacted-by-default secret-exposure triage

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -8,9 +8,16 @@ Release announcements and focused notes about new forensic workflows.
 
 ## Latest
 
+### [IRFlow Timeline 1.0.9 — Large EVTX Imports Fixed](/blog/v1.0.9-large-evtx-imports)
+
+**July 27, 2026**
+
+Bounded 64 KiB EVTX chunk parsing removes the Node 2 GiB failure, supports Windows Event Logs up to the format's approximately 4 GiB ceiling, and prevents duplicate pending imports and error notifications.
+
+## Previous Releases
+
 ### [IRFlow Timeline 1.0.8 — AI Application Forensics Expanded](/blog/v1.0.8-ai-application-forensics)
 
 **July 27, 2026**
 
 Grok Build support, deeper Claude Desktop/Cowork and Codex recovery, exact AI tool-command evidence, collection-scale triage, and major Process Inspector improvements.
-

--- a/docs/blog/v1.0.9-large-evtx-imports.md
+++ b/docs/blog/v1.0.9-large-evtx-imports.md
@@ -1,0 +1,44 @@
+---
+title: IRFlow Timeline 1.0.9 — Large EVTX Imports Fixed
+description: IRFlow Timeline 1.0.9 removes the Node 2 GiB EVTX import failure with bounded native chunk parsing and improves duplicate import recovery.
+---
+
+# IRFlow Timeline 1.0.9 — Large EVTX Imports Fixed
+
+**Published July 27, 2026**
+
+IRFlow Timeline 1.0.9 is a focused reliability update for investigations that depend on multi-gigabyte Windows Event Logs.
+
+## The 2 GiB failure
+
+Raw EVTX import previously opened the complete source through Node's whole-file `readFile()` path. Node cannot represent files larger than 2 GiB in one Buffer, so a large `Security.evtx` failed before IRFlow could parse its first event.
+
+[GitHub issue #22](https://github.com/r3nzsec/irflow-timeline/issues/22) captured the failure on a 4,109,438,976-byte (~3.83 GiB) Security log.
+
+## Bounded native EVTX parsing
+
+EVTX is already organized for streaming: a 4 KiB file header followed by independent 64 KiB chunks. IRFlow now follows that structure directly:
+
+- Reads and validates the EVTX file header once
+- Reads one native 64 KiB chunk at a time
+- Parses and inserts records before advancing to the next chunk
+- Reports progress from physical chunk offsets
+- Supports the format's maximum 65,535 declared chunks—approximately 4 GiB
+
+Parser memory therefore stays bounded as the source file grows instead of retaining the entire EVTX in JavaScript memory.
+
+## Cleaner import recovery
+
+This patch also prevents the same source from being queued repeatedly while it is already pending or running. If a failure does occur, identical notifications collapse into one retryable alert instead of stacking across the interface.
+
+Distinct Excel sheets and AI-history collection scopes remain separate import jobs.
+
+## Validation
+
+The regression suite uses the exact 4,109,438,976-byte size reported in issue #22 and verifies that individual source reads remain limited to 64 KiB. The production parser was also validated against a real 2.45 GiB `Security.evtx` and a complete smaller EVTX import.
+
+## Get v1.0.9
+
+- [Download IRFlow Timeline 1.0.9](https://github.com/r3nzsec/irflow-timeline/releases/tag/v1.0.9)
+- [Supported formats and EVTX details](/getting-started/supported-formats)
+- [Full changelog](/about/changelog)

--- a/docs/getting-started/architecture.md
+++ b/docs/getting-started/architecture.md
@@ -6,7 +6,7 @@ description: IRFlow Timeline architecture — React renderer, Electron main proc
 
 Technical overview of IRFlow Timeline's architecture for developers and contributors.
 
-> **v1.0.6+ modular layout (current: v1.0.8).** What was once a ~20K-line `App.jsx` and monolithic `electron/parser.js` / `electron/db.js` is now decomposed into focused modules across the renderer and main process (`parsers/`, `ipc/`, `jobs/`, `analyzers/`, and related trees). v1.0.8 extends the AI parser subsystem, triage collection orchestration, worker lifecycle controls, and multi-source analyzers. The file references below reflect that layout.
+> **v1.0.6+ modular layout (current: v1.0.9).** What was once a ~20K-line `App.jsx` and monolithic `electron/parser.js` / `electron/db.js` is now decomposed into focused modules across the renderer and main process (`parsers/`, `ipc/`, `jobs/`, `analyzers/`, and related trees). v1.0.8 extended the AI parser subsystem, triage collection orchestration, worker lifecycle controls, and multi-source analyzers; v1.0.9 adds bounded native EVTX chunk ingestion. The file references below reflect that layout.
 
 ## System Architecture
 

--- a/docs/getting-started/auto-update.md
+++ b/docs/getting-started/auto-update.md
@@ -67,13 +67,14 @@ For each macOS release, upload these files to the HTTPS/CDN path referenced by `
 
 - The `.zip` artifact
 - The `.dmg` artifact
+- The matching `.zip.blockmap` and `.dmg.blockmap` artifacts
 - `latest-mac.yml` for the default channel, or `<channel>-mac.yml` for a custom channel
 
 Requirements:
 
 - The app must be signed and notarized
 - The hosted files must be reachable over HTTPS
-- The `.zip` and `latest-mac.yml` must stay together at the same feed root
+- The `.zip`, its exact `.zip.blockmap`, and `latest-mac.yml` must stay together at the same feed root for differential updates
 
 ## Release Automation
 

--- a/docs/getting-started/supported-formats.md
+++ b/docs/getting-started/supported-formats.md
@@ -69,6 +69,8 @@ Native binary parsing of Windows Event Log files using the `@ts-evtx` library. N
 ### Features
 
 - **Binary parsing** — reads EVTX format directly, no conversion step
+- **Bounded native reads** — validates the 4 KiB file header, then parses one 64 KiB EVTX chunk at a time instead of loading the complete log into memory
+- **Large-log support** — handles up to 65,535 declared chunks (approximately 4 GiB), including multi-gigabyte Security logs that exceed Node's 2 GiB whole-file Buffer ceiling
 - **Dynamic schema discovery** — samples the first 500 events to discover all available fields
 - **Fixed fields** extracted from every event:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,13 +47,13 @@ features:
     details: Bookmarks, color-coded tags, conditional formatting with KAPE-aware presets, and full session save/restore.
 ---
 
-## What's New · v1.0.8
+## What's New · v1.0.9
 
-- **Grok Build support (new)** — Parse Grok AI prompts, responses, reasoning, exact terminal commands, completion output, session metadata, and file-change hunks.
-- **Expanded AI application forensics** — Deeper Claude Desktop/Cowork transcripts and audit trails, Codex SQLite recovery with WAL/SHM, and bounded tool evidence across supported assistants.
-- **Collection-scale investigations** — Open KAPE/triage collections and pivot through the upgraded Process Inspector, Persistence Analyzer, and Lateral Movement Tracker.
+- **Multi-gigabyte EVTX imports fixed** — Raw Windows Event Logs no longer hit Node's 2 GiB whole-file Buffer ceiling.
+- **Bounded native EVTX parsing** — IRFlow reads one 64 KiB EVTX chunk at a time, supporting logs up to the format's approximately 4 GiB ceiling with stable parser memory.
+- **Cleaner import recovery** — Duplicate pending imports are suppressed and identical failures collapse into one retryable notification.
 
-[Read the v1.0.8 announcement →](/blog/v1.0.8-ai-application-forensics) · [Full changelog →](/about/changelog)
+[Read the v1.0.9 announcement →](/blog/v1.0.9-large-evtx-imports) · [AI application forensics in v1.0.8 →](/blog/v1.0.8-ai-application-forensics) · [Full changelog →](/about/changelog)
 
 ## What is IRFlow Timeline?
 
@@ -76,7 +76,7 @@ Excel row limits, Windows VM overhead, or missing AI evidence — IRFlow is the 
 |--------|-----------|-------------|
 | **CSV/TSV** | `.csv`, `.tsv`, `.txt`, `.log` | Auto-detects delimiters (comma, tab, pipe) |
 | **Excel** | `.xlsx`, `.xls`, `.xlsm` | Streaming reader (XLSX) + legacy binary parser (XLS) with sheet selection |
-| **EVTX** | `.evtx` | Windows Event Log binary format |
+| **EVTX** | `.evtx` | Windows Event Log binary format; bounded 64 KiB chunk parsing up to the format's ~4 GiB limit |
 | **Plaso** | `.plaso`, `.timeline` | Forensic timeline database (`.timeline` auto-detects; falls back to CSV) |
 | **Raw $MFT** | `.mft` | NTFS Master File Table — direct import for NTFS analysis tools |
 | **Raw $J** | `.$J`, `.usn` | NTFS USN Journal (change journal) |

--- a/docs/public/dfir-tips/Architecture-Diagram.svg
+++ b/docs/public/dfir-tips/Architecture-Diagram.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 1190" role="img" aria-labelledby="title desc">
   <title id="title">IRFlow Timeline current architecture</title>
-  <desc id="desc">IRFlow Timeline v1.0.8 architecture with a semantic color system: orange = UI/output surface, violet = secure IPC bridge, blue = orchestration and network, amber = ingestion and compute, green = data and persistence, red = forensic detection. Shows the React renderer, preload bridge, Electron main services with grouped IPC, a worker-thread pool, the SQLite data engine with analyzers (including AI history parsers and AI Secret Hunt), the dual Sigma/Hayabusa detection engine, streaming parsers, and side connectors for evidence, external tools, network, state, and outputs.</desc>
+  <desc id="desc">IRFlow Timeline v1.0.9 architecture with a semantic color system: orange = UI/output surface, violet = secure IPC bridge, blue = orchestration and network, amber = ingestion and compute, green = data and persistence, red = forensic detection. Shows the React renderer, preload bridge, Electron main services with grouped IPC, a worker-thread pool, the SQLite data engine with analyzers (including AI history parsers and AI Secret Hunt), the dual Sigma/Hayabusa detection engine, streaming parsers, and side connectors for evidence, external tools, network, state, and outputs.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0%" stop-color="#0b1016"/>
@@ -76,9 +76,9 @@
   <circle cx="140" cy="1090" r="200" fill="rgba(232,93,42,0.035)"/>
 
   <text x="220" y="56" class="title">IRFlow Timeline Architecture</text>
-  <text x="220" y="82" class="subtitle">Modular v1.0.8 codebase — focused renderer + main-process modules.</text>
+  <text x="220" y="82" class="subtitle">Modular v1.0.9 codebase — focused renderer + main-process modules.</text>
   <rect x="220" y="96" width="190" height="24" class="badge"/>
-  <text x="315" y="112" text-anchor="middle" class="tiny">v1.0.8 workspace snapshot</text>
+  <text x="315" y="112" text-anchor="middle" class="tiny">v1.0.9 workspace snapshot</text>
 
   <!-- ============ LEFT SIDE BOXES ============ -->
   <rect x="40" y="150" width="152" height="212" class="side" stroke="#d29922" stroke-opacity="0.55" filter="url(#shadow)"/>

--- a/electron/ipc/session-handlers.js
+++ b/electron/ipc/session-handlers.js
@@ -23,8 +23,8 @@ function enqueuePlannedImports(planned, enqueueImport) {
       });
       continue;
     }
-    enqueueImport(item.path, item.opts || {});
-    enqueued += 1;
+    const accepted = enqueueImport(item.path, item.opts || {});
+    if (accepted !== false) enqueued += 1;
   }
   return { enqueued, scopePending };
 }

--- a/electron/main.js
+++ b/electron/main.js
@@ -17,6 +17,7 @@ const { getXLSXSheets, extractResidentData } = require("./parsers");
 const { createUpdateController } = require("./updater");
 const { JobManager } = require("./jobs/job-manager");
 const { resolveTempDir } = require("./utils/temp-dir");
+const { makeImportQueueKey, isDuplicatePendingImport } = require("./utils/import-queue");
 const { buildMenu: _buildMenu } = require("./menu");
 const packageMeta = require("../package.json");
 
@@ -140,6 +141,7 @@ const updateController = createUpdateController({
 // ── Import queue — serialize file imports to prevent concurrent memory exhaustion ──
 const _importQueue = [];
 let _importRunning = false;
+let _activeImportKey = null;
 const _pendingIndexTabs = []; // tabs waiting for index/FTS build (deferred until queue drains)
 const _indexBuildQueue = [];
 const _queuedIndexTabs = new Set();
@@ -166,14 +168,21 @@ function _cleanupDbFiles(dbPath) {
 }
 
 function enqueueImport(filePath, opts) {
+  const queueKey = makeImportQueueKey(filePath, opts);
+  if (isDuplicatePendingImport(_importQueue, _activeImportKey, queueKey)) {
+    dbg("QUEUE", "Skipped duplicate pending import", { filePath, sheetName: opts?.sheetName });
+    return false;
+  }
+
   let fileName;
   if (opts?.displayName) { fileName = opts.displayName; }
   else { try { fileName = decodeURIComponent(path.basename(filePath)); } catch { fileName = path.basename(filePath); } }
   let fileSize = 0; try { fileSize = fs.statSync(filePath).size; } catch {}
-  _importQueue.push({ filePath, fileName, fileSize, ...opts });
+  _importQueue.push({ filePath, fileName, fileSize, ...opts, queueKey });
   if (!opts?.skipRecent) addRecentFile(filePath);
   _broadcastQueue();
   _processQueue();
+  return true;
 }
 
 /**
@@ -205,6 +214,7 @@ async function _processQueue() {
 
   while (_importQueue.length > 0) {
     const item = _importQueue.shift();
+    _activeImportKey = item.queueKey;
     _broadcastQueue();
 
     // Log memory before import
@@ -222,6 +232,7 @@ async function _processQueue() {
         error: err?.message || "Import failed",
       });
     }
+    _activeImportKey = null;
     _broadcastQueue();
 
     if (_importQueue.length > 0) {

--- a/electron/parsers/evtx.js
+++ b/electron/parsers/evtx.js
@@ -13,6 +13,75 @@ const { getEvtxMessageSummaryFields, getEvtxWellKnownDataFields } = require("../
 const BATCH_SIZE_DEFAULT = 100000;
 const BATCH_SIZE_MAX_BYTES = 100 * 1024 * 1024; // ~100MB target max per batch
 const FAST_MESSAGE_THRESHOLD_BYTES = 256 * 1024 * 1024;
+const EVTX_FILE_HEADER_BYTES = 0x1000;
+const EVTX_CHUNK_BYTES = 0x10000;
+
+async function readFullyAt(handle, buffer, position) {
+  let offset = 0;
+  while (offset < buffer.length) {
+    const { bytesRead } = await handle.read(buffer, offset, buffer.length - offset, position + offset);
+    if (bytesRead === 0) break;
+    offset += bytesRead;
+  }
+  return offset;
+}
+
+/**
+ * Iterate EVTX records without ever materializing the complete file.
+ *
+ * @ts-evtx/core's EvtxFile.open() calls fs.promises.readFile(), which fails at
+ * Node's 2 GiB whole-file Buffer limit (and the dependency additionally rejects
+ * files over 100 MiB after reading them). EVTX is natively split into a 4 KiB
+ * file header followed by independent 64 KiB chunks, so read and parse exactly
+ * one chunk at a time instead.
+ */
+async function* iterateEvtxRecords(filePath, core, knownSize = 0) {
+  const { BinaryReader, FileHeader, ChunkHeader } = core;
+  const handle = await fs.promises.open(filePath, "r");
+
+  try {
+    const stat = knownSize > 0 ? { size: knownSize } : await handle.stat();
+    const totalBytes = Number(stat.size) || 0;
+    const headerBytes = Buffer.alloc(EVTX_FILE_HEADER_BYTES);
+    const headerRead = await readFullyAt(handle, headerBytes, 0);
+    if (headerRead !== EVTX_FILE_HEADER_BYTES) {
+      throw new Error("Invalid EVTX file: incomplete file header");
+    }
+
+    const header = new FileHeader(new BinaryReader(headerBytes), 0);
+    if (!header.verify()) {
+      throw new Error("Invalid EVTX file: header verification failed");
+    }
+
+    const declaredChunks = Math.max(0, Number(header.chunkCount()) || 0);
+    const physicalChunks = Math.max(0, Math.floor((totalBytes - EVTX_FILE_HEADER_BYTES) / EVTX_CHUNK_BYTES));
+    const chunkCount = Math.min(declaredChunks, physicalChunks);
+    dbg("EVTX", "Using bounded chunk reader", {
+      totalBytes,
+      declaredChunks,
+      physicalChunks,
+      chunkCount,
+      maxResidentReadBytes: EVTX_FILE_HEADER_BYTES + EVTX_CHUNK_BYTES,
+    });
+
+    const chunkBytes = Buffer.alloc(EVTX_CHUNK_BYTES);
+    for (let chunkIndex = 0; chunkIndex < chunkCount; chunkIndex++) {
+      const position = EVTX_FILE_HEADER_BYTES + (chunkIndex * EVTX_CHUNK_BYTES);
+      const chunkRead = await readFullyAt(handle, chunkBytes, position);
+      if (chunkRead !== EVTX_CHUNK_BYTES) break;
+
+      const chunk = new ChunkHeader(new BinaryReader(chunkBytes), 0);
+      if (!chunk.checkMagic()) continue;
+
+      const bytesRead = position + chunkRead;
+      for (const record of chunk.records()) {
+        yield { record, bytesRead, chunkIndex, chunkCount };
+      }
+    }
+  } finally {
+    await handle.close();
+  }
+}
 
 // ── Cached EVTX message provider (created once, reused across all EVTX imports) ──
 let _cachedMsgProvider = null;
@@ -241,7 +310,7 @@ function buildCompactEvtxMessage(eventId, provider, dataMap) {
  * @returns {Promise<{headers, rowCount, tsColumns, numericColumns}>}
  */
 async function parseEvtxFile(filePath, tabId, db, onProgress) {
-  const { EvtxFile } = await import("@ts-evtx/core");
+  const evtxCore = await import("@ts-evtx/core");
   let totalBytes = 0;
   try { totalBytes = fs.statSync(filePath).size; } catch { /* proceed with 0 */ }
   const SAMPLE_LIMIT = 500;
@@ -417,92 +486,83 @@ async function parseEvtxFile(filePath, tabId, db, onProgress) {
     return values;
   };
 
-  const evtxFile = await EvtxFile.open(filePath);
   // Yield to event loop before starting to allow pending IPC to process
   await new Promise((r) => setImmediate(r));
 
-  try {
-    for (const record of evtxFile.records()) {
-      let parsed;
-      try {
-        parsed = parseStructuredRecord(record);
-      } catch {
-        let xml;
-        try { xml = record.renderXml(); } catch { continue; }
-        parsed = parseXmlRecord(xml, record);
-      }
-      rowCount++;
-
-      if (!schemaFinalized) {
-        for (const key of Object.keys(parsed.dataMap)) fieldSet.add(key);
-        earlyBuffer.push(parsed);
-
-        if (rowCount >= SAMPLE_LIMIT) {
-          // Union well-known fields into the discovered set so analyzers always
-          // have the columns they need even when the early sample is skewed.
-          for (const f of EVTX_WELL_KNOWN_DATA_FIELDS) fieldSet.add(f);
-          const discoveredFields = [...fieldSet].sort();
-          headers = [...EVTX_FIXED_FIELDS, ...discoveredFields];
-          colCount = headers.length;
-          db.createTab(tabId, headers);
-          batchSize = Math.max(5000, Math.min(BATCH_SIZE_DEFAULT, Math.floor(BATCH_SIZE_MAX_BYTES / (colCount * 80))));
-          schemaFinalized = true;
-
-          for (const buf of earlyBuffer) batch.push(buildRow(buf));
-          earlyBuffer = null;
-
-          if (batch.length >= batchSize) {
-            db.insertBatchArrays(tabId, batch);
-            batch = [];
-          }
-          if (onProgress) { let eo = 0; try { eo = record.offset ? Number(record.offset) : 0; } catch {} onProgress(rowCount, eo, totalBytes); }
-        }
-        continue;
-      }
-
-      batch.push(buildRow(parsed));
-      if (batch.length >= batchSize) {
-        db.insertBatchArrays(tabId, batch);
-        batch = [];
-        if (rowCount - lastProgress >= 10000) {
-          lastProgress = rowCount;
-          // Estimate bytes read from record offset when available
-          let estBytes = 0;
-          try { estBytes = record.offset ? Number(record.offset) : 0; } catch {}
-          if (onProgress) onProgress(rowCount, estBytes, totalBytes);
-          // Yield to event loop periodically so IPC remains responsive
-          await new Promise((r) => setImmediate(r));
-        }
-      }
+  for await (const { record, bytesRead } of iterateEvtxRecords(filePath, evtxCore, totalBytes)) {
+    let parsed;
+    try {
+      parsed = parseStructuredRecord(record);
+    } catch {
+      let xml;
+      try { xml = record.renderXml(); } catch { continue; }
+      parsed = parseXmlRecord(xml, record);
     }
+    rowCount++;
 
-    // Handle files with fewer than SAMPLE_LIMIT events
     if (!schemaFinalized) {
-      if (rowCount === 0) {
-        // No events at all
-        headers = [...EVTX_FIXED_FIELDS];
-        colCount = headers.length;
-        db.createTab(tabId, headers);
-      } else {
+      for (const key of Object.keys(parsed.dataMap)) fieldSet.add(key);
+      earlyBuffer.push(parsed);
+
+      if (rowCount >= SAMPLE_LIMIT) {
         // Union well-known fields into the discovered set so analyzers always
-        // have the columns they need even when the file has fewer than
-        // SAMPLE_LIMIT records (and might still be missing a key field).
+        // have the columns they need even when the early sample is skewed.
         for (const f of EVTX_WELL_KNOWN_DATA_FIELDS) fieldSet.add(f);
         const discoveredFields = [...fieldSet].sort();
         headers = [...EVTX_FIXED_FIELDS, ...discoveredFields];
         colCount = headers.length;
         db.createTab(tabId, headers);
+        batchSize = Math.max(5000, Math.min(BATCH_SIZE_DEFAULT, Math.floor(BATCH_SIZE_MAX_BYTES / (colCount * 80))));
+        schemaFinalized = true;
+
         for (const buf of earlyBuffer) batch.push(buildRow(buf));
         earlyBuffer = null;
+
+        if (batch.length >= batchSize) {
+          db.insertBatchArrays(tabId, batch);
+          batch = [];
+        }
+        if (onProgress) onProgress(rowCount, bytesRead, totalBytes);
       }
+      continue;
     }
 
-    if (batch.length > 0) {
+    batch.push(buildRow(parsed));
+    if (batch.length >= batchSize) {
       db.insertBatchArrays(tabId, batch);
+      batch = [];
+      if (rowCount - lastProgress >= 10000) {
+        lastProgress = rowCount;
+        if (onProgress) onProgress(rowCount, bytesRead, totalBytes);
+        // Yield to event loop periodically so IPC remains responsive
+        await new Promise((r) => setImmediate(r));
+      }
     }
-  } finally {
-    // Always close the EVTX file handle to release memory
-    try { if (evtxFile?.close) evtxFile.close(); } catch {}
+  }
+
+  // Handle files with fewer than SAMPLE_LIMIT events
+  if (!schemaFinalized) {
+    if (rowCount === 0) {
+      // No events at all
+      headers = [...EVTX_FIXED_FIELDS];
+      colCount = headers.length;
+      db.createTab(tabId, headers);
+    } else {
+      // Union well-known fields into the discovered set so analyzers always
+      // have the columns they need even when the file has fewer than
+      // SAMPLE_LIMIT records (and might still be missing a key field).
+      for (const f of EVTX_WELL_KNOWN_DATA_FIELDS) fieldSet.add(f);
+      const discoveredFields = [...fieldSet].sort();
+      headers = [...EVTX_FIXED_FIELDS, ...discoveredFields];
+      colCount = headers.length;
+      db.createTab(tabId, headers);
+      for (const buf of earlyBuffer) batch.push(buildRow(buf));
+      earlyBuffer = null;
+    }
+  }
+
+  if (batch.length > 0) {
+    db.insertBatchArrays(tabId, batch);
   }
   // Null out large arrays to help GC before next import
   batch = null;
@@ -526,4 +586,10 @@ async function parseEvtxFile(filePath, tabId, db, onProgress) {
   };
 }
 
-module.exports = { parseEvtxFile };
+module.exports = {
+  parseEvtxFile,
+  _iterateEvtxRecords: iterateEvtxRecords,
+  _readFullyAt: readFullyAt,
+  EVTX_FILE_HEADER_BYTES,
+  EVTX_CHUNK_BYTES,
+};

--- a/electron/utils/import-queue.js
+++ b/electron/utils/import-queue.js
@@ -1,0 +1,16 @@
+const path = require("path");
+
+function makeImportQueueKey(filePath, opts = {}) {
+  return [
+    path.resolve(filePath),
+    opts.sheetName ?? "",
+    opts.aiHistoryTool ?? "",
+    opts.aiHistoryIncludeSubagents ? "subagents" : "main",
+  ].join("\u0000");
+}
+
+function isDuplicatePendingImport(queue, activeKey, queueKey) {
+  return activeKey === queueKey || queue.some((item) => item.queueKey === queueKey);
+}
+
+module.exports = { makeImportQueueKey, isDuplicatePendingImport };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "irflow-timeline",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "irflow-timeline",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "irflow-timeline",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "IRFlow Timeline is a high-performance, SQLite-backed DFIR investigation workspace for macOS that turns large forensic datasets, native artifacts, and AI application histories into searchable timelines with source provenance.",
   "main": "electron/main.js",
   "author": "DFIR Community",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3696,7 +3696,7 @@ export default function App() {
                 {APP_DESCRIPTION}
               </p>
               <p style={{ margin: "0 0 8px", fontSize: 12, color: th.text, lineHeight: 1.6, fontFamily: "-apple-system, sans-serif" }}>
-                Native ingestion covers CSV, TSV, XLS/XLSX, EVTX, Plaso, raw $MFT and $UsnJrnl, plus prompts, responses, tool calls, shell commands, and bounded tool output from supported AI assistants.
+                Native ingestion covers CSV, TSV, XLS/XLSX, Plaso, raw $MFT and $UsnJrnl, plus EVTX through bounded 64 KiB chunk reads up to the format's approximately 4 GiB limit. AI evidence includes prompts, responses, tool calls, shell commands, and bounded tool output from supported assistants.
               </p>
               <p style={{ margin: 0, fontSize: 12, color: th.text, lineHeight: 1.6, fontFamily: "-apple-system, sans-serif" }}>
                 Built-in investigation includes Sigma and Hayabusa detection, process trees, lateral movement, persistence, ransomware and NTFS analytics, AI secret exposure hunting, IOC and VirusTotal enrichment, RDP bitmap recovery, tagging, and reporting.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1302,6 +1302,7 @@ export default function App() {
       delete importPathsRef.current[tabId];
       toast.error("Import failed", {
         detail: errText,
+        dedupeKey: failedPath ? `import-error:${failedPath}` : `import-error:${errText}`,
         ...(failedPath ? { actionLabel: "Retry import", onAction: () => tle?.importFiles([failedPath]) } : {}),
       });
     });

--- a/src/store/useToastStore.js
+++ b/src/store/useToastStore.js
@@ -20,25 +20,47 @@ import { create } from "zustand";
  *   error           — does NOT auto-dismiss (requires user action)
  */
 let nextId = 1;
+const ttlTimers = new Map();
 
 const DEFAULT_TTL = { info: 3500, success: 3500, warning: 6000, error: 0 };
 
 const useToastStore = create((set, get) => ({
   toasts: [],
 
-  push: ({ kind = "info", message, detail, ttl, actionLabel, onAction }) => {
-    const id = nextId++;
+  push: ({ kind = "info", message, detail, ttl, actionLabel, onAction, dedupeKey }) => {
     const effectiveTtl = ttl !== undefined ? ttl : DEFAULT_TTL[kind] ?? 3500;
-    set((s) => ({ toasts: [...s.toasts, { id, kind, message, detail, ttl: effectiveTtl, actionLabel, onAction }] }));
+    let id;
+    set((s) => {
+      const existing = dedupeKey ? s.toasts.find((item) => item.dedupeKey === dedupeKey) : null;
+      id = existing?.id ?? nextId++;
+      const item = { id, kind, message, detail, ttl: effectiveTtl, actionLabel, onAction, dedupeKey };
+      return {
+        toasts: existing
+          ? s.toasts.map((toastItem) => toastItem.id === id ? item : toastItem)
+          : [...s.toasts, item],
+      };
+    });
+
+    const priorTimer = ttlTimers.get(id);
+    if (priorTimer) clearTimeout(priorTimer);
     if (effectiveTtl > 0) {
-      setTimeout(() => get().dismiss(id), effectiveTtl);
+      ttlTimers.set(id, setTimeout(() => get().dismiss(id), effectiveTtl));
     }
     return id;
   },
 
-  dismiss: (id) => set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) })),
+  dismiss: (id) => {
+    const timer = ttlTimers.get(id);
+    if (timer) clearTimeout(timer);
+    ttlTimers.delete(id);
+    set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));
+  },
 
-  clear: () => set({ toasts: [] }),
+  clear: () => {
+    for (const timer of ttlTimers.values()) clearTimeout(timer);
+    ttlTimers.clear();
+    set({ toasts: [] });
+  },
 }));
 
 export default useToastStore;

--- a/tests/evtx-large-file-stream.test.js
+++ b/tests/evtx-large-file-stream.test.js
@@ -1,0 +1,67 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  _iterateEvtxRecords,
+  EVTX_FILE_HEADER_BYTES,
+  EVTX_CHUNK_BYTES,
+} = require("../electron/parsers/evtx");
+
+test("EVTX reader keeps reads bounded at the 4,109,438,976-byte issue #22 size", async (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "irflow-evtx-large-"));
+  const filePath = path.join(tempDir, "Security.evtx");
+  const fileSize = 4_109_438_976;
+  const fd = fs.openSync(filePath, "w");
+  fs.writeSync(fd, Buffer.alloc(EVTX_FILE_HEADER_BYTES + EVTX_CHUNK_BYTES), 0);
+  fs.ftruncateSync(fd, fileSize); // sparse: logical size >2 GiB, physical allocation stays tiny
+  fs.closeSync(fd);
+  t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }));
+
+  const readerSizes = [];
+  class BinaryReader {
+    constructor(buffer) {
+      readerSizes.push(buffer.byteLength);
+    }
+  }
+  class FileHeader {
+    verify() { return true; }
+    chunkCount() { return 1; }
+  }
+  class ChunkHeader {
+    checkMagic() { return true; }
+    *records() {
+      yield { id: 1 };
+      yield { id: 2 };
+    }
+  }
+
+  const records = [];
+  for await (const item of _iterateEvtxRecords(filePath, { BinaryReader, FileHeader, ChunkHeader })) {
+    records.push(item);
+  }
+
+  assert.equal(fs.statSync(filePath).size, fileSize);
+  assert.deepEqual(records.map(({ record }) => record.id), [1, 2]);
+  assert.deepEqual(readerSizes, [EVTX_FILE_HEADER_BYTES, EVTX_CHUNK_BYTES]);
+  assert.equal(records[0].bytesRead, EVTX_FILE_HEADER_BYTES + EVTX_CHUNK_BYTES);
+});
+
+test("EVTX reader rejects an incomplete header with a forensic format error", async (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "irflow-evtx-short-"));
+  const filePath = path.join(tempDir, "truncated.evtx");
+  fs.writeFileSync(filePath, Buffer.alloc(128));
+  t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }));
+
+  class BinaryReader {}
+  class FileHeader {}
+  class ChunkHeader {}
+
+  await assert.rejects(async () => {
+    for await (const _item of _iterateEvtxRecords(filePath, { BinaryReader, FileHeader, ChunkHeader })) {
+      // No records are expected.
+    }
+  }, /incomplete file header/);
+});

--- a/tests/import-queue-dedupe.test.js
+++ b/tests/import-queue-dedupe.test.js
@@ -1,0 +1,32 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  makeImportQueueKey,
+  isDuplicatePendingImport,
+} = require("../electron/utils/import-queue");
+
+test("repeated imports of the same file are deduplicated while pending", () => {
+  const key = makeImportQueueKey("/evidence/Security.evtx");
+  assert.equal(isDuplicatePendingImport([], key, key), true);
+  assert.equal(isDuplicatePendingImport([{ queueKey: key }], null, key), true);
+});
+
+test("the same workbook can still queue distinct sheet imports", () => {
+  const first = makeImportQueueKey("/evidence/timeline.xlsx", { sheetName: 1 });
+  const second = makeImportQueueKey("/evidence/timeline.xlsx", { sheetName: 2 });
+  assert.notEqual(first, second);
+  assert.equal(isDuplicatePendingImport([{ queueKey: first }], null, second), false);
+});
+
+test("AI history scope remains part of the import identity", () => {
+  const mainOnly = makeImportQueueKey("/evidence/.claude", {
+    aiHistoryTool: "claude",
+    aiHistoryIncludeSubagents: false,
+  });
+  const withSubagents = makeImportQueueKey("/evidence/.claude", {
+    aiHistoryTool: "claude",
+    aiHistoryIncludeSubagents: true,
+  });
+  assert.notEqual(mainOnly, withSubagents);
+});


### PR DESCRIPTION
## Summary

- release IRFlow Timeline 1.0.9 as a focused reliability patch for issue #22
- replace `EvtxFile.open()` whole-file reads with native EVTX 64 KiB chunk streaming
- remove both the Node 2 GiB Buffer ceiling and the dependency's post-read 100 MiB rejection from raw EVTX imports
- report progress from physical chunk offsets while keeping parser memory bounded
- deduplicate identical pending imports and repeated failure toasts
- update the About dialog, package metadata, changelog, VitePress site, architecture graphic, and release-workflow defaults to v1.0.9

## Root cause

`@ts-evtx/core` 1.1.1 implements `EvtxFile.open()` with `fs.promises.readFile()`. Node refuses a single Buffer larger than 2 GiB, so the parser failed before reading the first EVTX record. It also retained the complete file in memory for smaller inputs.

## Validation

- `npm test`: 1,195 passed, 0 failed, 50 skipped (existing local better-sqlite3 Node/Electron ABI mismatch)
- `npm run build:renderer`: passed
- `npm run docs:build`: passed
- `npm run dist:smoke`: passed; created universal v1.0.9 DMG, ZIP, and both blockmaps
- local DMG checksum: valid; mounted app version/build: 1.0.9; executable architectures: x86_64 and arm64
- parsed a complete 200,704-byte real EVTX: 166 rows, 141 columns
- read 1,000 records from a real 2,627,801,088-byte `Security.evtx`: about 2 MiB RSS growth
- exact-size sparse regression: 4,109,438,976 bytes, maximum bounded read 64 KiB

Fixes #22
