### PR TITLE
fix(ci): pin Node 22.17 — better-sqlite3 13 segfaults on Node 22.12/22.13

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.12.0
+          node-version: 22.17.0
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.12.0
+          node-version: 22.17.0
           cache: npm
 
       - name: Ensure release tools
@@ -108,11 +108,27 @@ jobs:
       - name: Smoke Electron and native SQLite runtime
         run: npm run smoke:electron
 
-      # The project postinstall prepares better-sqlite3 for local Electron use.
-      # Restore the Node ABI explicitly so SQLite-backed tests execute instead
-      # of being skipped. Packaging rebuilds the universal Electron module below.
-      - name: Rebuild SQLite for Node tests
-        run: npm rebuild better-sqlite3
+      # better-sqlite3 13 ships prebuildify prebuilds and has no install script, so
+      # `npm rebuild better-sqlite3` is a no-op for it — the Node binding comes from
+      # node_modules/better-sqlite3/prebuilds/. Packaging rebuilds the universal Electron
+      # module below.
+      #
+      # That prebuild segfaults on Node 22.12/22.13 (crash on Database construction, not a
+      # clean ABI error), which surfaced as 21 unexplained SIGSEGVs across every
+      # SQLite-backed test file. Assert it loads before running the suite so a future
+      # runtime break fails here with one clear message instead of inside the tests.
+      - name: Verify native SQLite under the test runtime
+        run: |
+          set -euo pipefail
+          node -e "
+            const Database = require('better-sqlite3');
+            const db = new Database(':memory:');
+            db.exec('CREATE TABLE probe (v INTEGER)');
+            db.prepare('INSERT INTO probe VALUES (?)').run(1);
+            if (db.prepare('SELECT v FROM probe').get().v !== 1) throw new Error('probe query failed');
+            db.close();
+            console.log('better-sqlite3 OK under Node ' + process.versions.node);
+          "
 
       - name: Run test suite
         timeout-minutes: 10
@@ -342,7 +358,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.12.0
+          node-version: 22.17.0
           cache: npm
 
       - name: Ensure repair tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ crash-resilience update for long-running investigations.
 ### Supported Runtime
 
 - Upgraded Electron from 33 to 43, `better-sqlite3` from 11 to 13, Electron Builder to 26, Electron Rebuild to 4, and Electron Updater to 6.8.
-- Development and release automation now require Node.js 22.12 or newer. The EVTX message provider is pinned to the same SQLite 13 native addon so every SQLite call uses the Electron 43 ABI.
+- Development and release automation now require **Node.js 22.14 or newer**. The `better-sqlite3` 13 prebuilt binding segfaults when a database is opened under Node 22.12 and 22.13, so those two releases are not usable for building or testing even though they satisfy the package's own `>=22` floor. The EVTX message provider is pinned to the same SQLite 13 native addon so every SQLite call uses the Electron 43 ABI.
 - The packaged minimum is now explicit at macOS 12 (Monterey), matching Electron 43's supported platform floor.
 
 ## v1.0.9

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "DFIR Community",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=22.12.0"
+    "node": ">=22.14.0"
   },
   "scripts": {
     "dev": "concurrently \"vite\" \"TLE_DEV_SERVER=1 wait-on http://localhost:5173 && TLE_DEV_SERVER=1 electron .\"",


### PR DESCRIPTION
The v1.0.10 release run [failed](https://github.com/r3nzsec/irflow-timeline/actions/runs/31789073671) with **21 SIGSEGVs** across every SQLite-backed test file.

## Root cause

Not an Electron ABI mismatch. The `better-sqlite3` 13.0.3 prebuilt binding **loads** fine under Node 22.12.0/22.13.0 but **segfaults when a `Database` is constructed**.

Bisected on the CI runner architecture (macos-14 / darwin-arm64):

| Node | Result |
|------|--------|
| 22.12.0 | exit 139 (SIGSEGV) |
| 22.13.0 | exit 139 (SIGSEGV) |
| 22.14.0 | ok |
| 22.17.0 | ok — full suite 1347/1347 |

Two things let this reach a release:

- `better-sqlite3` 13 declares `engines.node >= 22`, which is wrong for 22.12 and 22.13.
- The failure is a segfault, not a clean ABI error, so nothing could guard against it — it surfaced only as unexplained test crashes.

This did not affect v1.0.9 because `better-sqlite3` 11 was in use; the 11 → 13 upgrade shipped in this release.

## Changes

- Pin CI to **Node 22.17.0** — both `release-macos.yml` jobs and `deploy-docs.yml`.
- Raise `package.json` `engines.node` to **>=22.14.0**, the verified floor (was `>=22.12.0`, which crashes).
- Replace the *"Rebuild SQLite for Node tests"* step with a **preflight probe**. That step ran `npm rebuild better-sqlite3`, which is a no-op for this package — better-sqlite3 13 uses prebuildify prebuilds and has no install script, so the comment describing it was also inaccurate. The probe opens a database, writes and reads a row, and fails the job at one named step with a clear message.
- CHANGELOG: correct the stated Node floor and record why 22.12/22.13 are unusable.

## Verification

- Probe exits **139** on 22.12.0/22.13.0 and **0** on 22.17.0
- Full suite **1347 passing, 0 failing** under Node 22.17.0
- No application code touched

## Note

No GitHub release or assets were published by the failed run, so `v1.0.10` can be re-cut cleanly once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)